### PR TITLE
Pin dependencies and disable pip version check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Use an official Python runtime as a parent image
 FROM python:3.10-slim
 
+# Disable pip's version check for faster installs
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+
 WORKDIR /app
 
 # Install OS dependencies as root

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 
 3. Install dependencies:
 ```bash
+# Optional: disable pip's version check to speed up installs
+export PIP_DISABLE_PIP_VERSION_CHECK=1
 pip install -r requirements.txt
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,10 +19,10 @@ asyncpg==0.30.0
 celery==5.5.2
 eventlet==0.33.3
 asgiref==3.8.1
-quart>=0.20.0
+quart==0.20.0
 python-socketio==5.11.2
 python-engineio==4.12.1
-quart-cors>=0.8
+quart-cors==0.8.0
 quart-schema==0.22.0
 asyncio-extras==1.3.2
 uvicorn==0.34.2
@@ -91,7 +91,7 @@ pytz==2023.3
 tenacity==8.2.3
 pydantic==2.11.5
 marshmallow==3.20.1
-httpx>=0.27.0
+httpx==0.28.1
 orjson==3.10.18
 validators==0.20.0
 jsonschema==4.20.0


### PR DESCRIPTION
## Summary
- pin remaining unpinned Python dependencies
- disable pip version check in the Dockerfile
- document how to disable pip version check in README

## Testing
- `pip install pytest pytest-cov pytest-asyncio pytest-mock pytest-flask coverage faker`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68409b8f01008321bec301ac44498689