### PR TITLE
Implement Strategy Manager

### DIFF
--- a/strategy/__init__.py
+++ b/strategy/__init__.py
@@ -1,0 +1,4 @@
+from .manager import current, apply, StrategyManager
+from .params import StrategyParams
+
+__all__ = ["current", "apply", "StrategyManager", "StrategyParams"]

--- a/strategy/manager.py
+++ b/strategy/manager.py
@@ -1,0 +1,84 @@
+"""Manage strategy parameters across runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+from .params import StrategyParams
+
+# Default location for strategy state
+STATE_PATH = Path("nyx_state.json")
+
+
+class StrategyManager:
+    """Load, modify and persist :class:`StrategyParams`."""
+
+    def __init__(self, path: Path | str = STATE_PATH):
+        self._path = Path(path)
+        self._params = self._load()
+
+    # ------------------------------------------------------------------
+    def _load(self) -> StrategyParams:
+        if self._path.exists():
+            try:
+                with self._path.open("r") as f:
+                    data = json.load(f)
+                # if strategy params stored under key 'strategy', handle
+                if set(data.keys()) <= set(StrategyParams.model_fields.keys()):
+                    return StrategyParams.model_validate(data)
+                if "strategy" in data:
+                    return StrategyParams.model_validate(data["strategy"])
+            except Exception:
+                pass
+        return StrategyParams()
+
+    def _save(self) -> None:
+        data = self._params.model_dump()
+        # if file contains other data keep them
+        if self._path.exists():
+            try:
+                with self._path.open("r") as f:
+                    existing = json.load(f)
+            except Exception:
+                existing = {}
+            if isinstance(existing, dict) and "strategy" not in existing:
+                existing.update(data)
+                data = existing
+            else:
+                existing["strategy"] = data
+                data = existing
+        with self._path.open("w") as f:
+            json.dump(data, f, indent=2)
+
+    # ------------------------------------------------------------------
+    def current(self) -> StrategyParams:
+        return self._params
+
+    async def apply(self, insight: str) -> None:
+        """Adjust parameters based on a reflective insight."""
+        text = insight.lower()
+        changed = False
+        if "math error" in text:
+            new_val = min(self._params.precision_focus + 0.1, 1.0)
+            if new_val != self._params.precision_focus:
+                self._params.precision_focus = new_val
+                changed = True
+
+        if changed:
+            self._save()
+
+
+# Default manager instance used by agents
+_manager = StrategyManager()
+
+
+def current() -> StrategyParams:
+    """Return current strategy parameters."""
+    return _manager.current()
+
+
+async def apply(insight: str) -> None:
+    """Public wrapper for :meth:`StrategyManager.apply`."""
+    await _manager.apply(insight)

--- a/strategy/params.py
+++ b/strategy/params.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+class StrategyParams(BaseModel):
+    """Parameters influencing agent strategy."""
+
+    exploration_rate: float = 0.2
+    precision_focus: float = 0.5
+    risk_tolerance: float = 0.4
+    creativity: float = 0.6

--- a/tests/test_strategy_manager.py
+++ b/tests/test_strategy_manager.py
@@ -1,0 +1,22 @@
+import json
+import pytest
+from strategy.manager import StrategyManager
+
+@pytest.mark.asyncio
+async def test_apply_updates_and_saves(tmp_path):
+    path = tmp_path / "nyx_state.json"
+    mgr = StrategyManager(path)
+    await mgr.apply("Too many math errors in output")
+    assert mgr.current().precision_focus == 0.6
+    with open(path) as f:
+        data = json.load(f)
+    assert data["precision_focus"] == 0.6
+
+
+def test_load_existing(tmp_path):
+    path = tmp_path / "nyx_state.json"
+    with open(path, "w") as f:
+        json.dump({"precision_focus": 0.7, "exploration_rate": 0.1,
+                   "risk_tolerance": 0.3, "creativity": 0.4}, f)
+    mgr = StrategyManager(path)
+    assert pytest.approx(mgr.current().precision_focus, 0.0001) == 0.7


### PR DESCRIPTION
## Summary
- add `StrategyParams` Pydantic model for strategy configuration
- implement persistent `StrategyManager` that loads/saves `nyx_state.json`
- expose helper functions for current params and applying insights
- test that the manager persists changes and loads saved state

## Testing
- `PYTHONPATH=. pytest tests/test_strategy_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684728fe908483219a6e9dd13f214c00