### PR TITLE
Improve coding practice loop

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include nyx/core/practice/problems.json

--- a/nyx/core/logging/event_logger.py
+++ b/nyx/core/logging/event_logger.py
@@ -2,7 +2,7 @@ import os
 import json
 import datetime
 import asyncio
-from reflection.reflection_agent import log_buffer, schedule_reflection
+
 
 LOG_DIR = "/mnt/nyx_logs"
 
@@ -13,8 +13,14 @@ async def log_event(event: dict) -> None:
     path = os.path.join(LOG_DIR, f"{date}.jsonl")
     line = json.dumps(event)
     await asyncio.to_thread(_append_line, path, line)
-    log_buffer.append(event)
-    await schedule_reflection()
+
+    try:
+        from reflection import reflection_agent as ra
+    except Exception:
+        return
+
+    ra.log_buffer.append(event)
+    await ra.schedule_reflection()
 
 
 def _append_line(path: str, line: str) -> None:

--- a/nyx/core/orchestrator.py
+++ b/nyx/core/orchestrator.py
@@ -37,15 +37,19 @@ async def prepare_context(ctx: str, user_msg: str) -> str:
 logger = logging.getLogger(__name__)
 _background_task = None
 _reflection_task = None
+_practice_task = None
 
 
 def start_background() -> None:
     """Start orchestrator background jobs."""
-    global _background_task, _reflection_task
+    global _background_task, _reflection_task, _practice_task
     if _background_task is None:
         _background_task = asyncio.create_task(_rollup_loop())
     if _reflection_task is None:
         _reflection_task = asyncio.create_task(_reflection_loop())
+    if _practice_task is None:
+        from nyx.core.practice.coding_practice import autoloop
+        _practice_task = asyncio.create_task(autoloop())
 
 
 async def _rollup_loop() -> None:

--- a/nyx/core/practice/coding_practice.py
+++ b/nyx/core/practice/coding_practice.py
@@ -1,0 +1,149 @@
+import asyncio
+import json
+import logging
+import os
+import random
+import re
+import time
+from datetime import date
+from importlib import resources
+from openai import OpenAIError
+
+from agents import Runner
+from nyx.nyx_agent_sdk import nyx_main_agent
+from nyx.core.tools import code_executor
+from nyx.core.reward import evaluator as reward
+
+try:
+    from nyx.core.conditioning_system import conditioning_system as cs
+except Exception:  # pragma: no cover - conditioning system optional
+    cs = None
+
+logger = logging.getLogger(__name__)
+
+_TIME_BUDGET = 30 * 60  # seconds per day
+_daily_time_spent = 0.0
+_last_day = date.today()
+_ITERATION_LIMIT = 600  # seconds
+
+
+def cpu_idle(threshold: float = 20.0) -> bool:
+    """Return True if CPU usage is below threshold percent."""
+    try:
+        import psutil  # type: ignore
+        return psutil.cpu_percent(interval=1) < threshold
+    except Exception:
+        try:
+            load1, _, _ = os.getloadavg()
+            cores = os.cpu_count() or 1
+            return load1 / cores < threshold / 100.0
+        except Exception:
+            return True
+
+
+def _reset_daily_budget() -> None:
+    global _daily_time_spent, _last_day
+    today = date.today()
+    if today != _last_day:
+        _daily_time_spent = 0.0
+        _last_day = today
+
+
+def _within_budget() -> bool:
+    _reset_daily_budget()
+    return _daily_time_spent < _TIME_BUDGET
+
+
+def _load_problems():
+    try:
+        path = resources.files(__package__).joinpath("problems.json")
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except Exception:
+        logger.warning("Unable to load problems.json")
+        return []
+
+_PROBLEMS = _load_problems()
+
+
+def _get_problem():
+    easy = [p for p in _PROBLEMS if p.get('difficulty', '').lower() == 'easy']
+    choices = easy if easy else _PROBLEMS
+    if not choices:
+        return None
+    return random.choice(choices)
+
+
+def _strip_md(text: str) -> str:
+    """Remove simple markdown fences from text."""
+    if not text:
+        return text
+    text = text.strip()
+    text = re.sub(r"^```(?:\w+)?\n", "", text)
+    text = re.sub(r"\n```$", "", text)
+    return text.strip()
+
+
+async def autoloop():
+    """Run idle-time coding practice loop."""
+    global _daily_time_spent
+    logger.info("Coding practice autoloop started")
+    while True:
+        iteration_start = None
+        try:
+            if not _within_budget():
+                await asyncio.sleep(600)
+                continue
+            if not cpu_idle():
+                await asyncio.sleep(60)
+                continue
+            problem = _get_problem()
+            if not problem:
+                await asyncio.sleep(300)
+                continue
+            iteration_start = time.time()
+            prompt = f"{problem.get('title')}\nSolve in Python, write tests."
+            try:
+                result = await Runner.run(nyx_main_agent, prompt)
+            except OpenAIError as e:
+                logger.warning("OpenAI error: %s", e)
+                await asyncio.sleep(900)
+                continue
+            except Exception as e:
+                logger.warning("Agent run failed: %s", e)
+                await asyncio.sleep(60)
+                continue
+            output = getattr(result, 'final_output', '') if result else ''
+            try:
+                data = json.loads(output)
+                code = data.get('code') or data.get('solution', '')
+                tests = data.get('tests', '')
+            except Exception:
+                code = output
+                tests = ''
+            code = _strip_md(code)
+            tests = _strip_md(tests)
+            try:
+                exec_res = await asyncio.wait_for(
+                    code_executor.execute_python(code, tests), timeout=_ITERATION_LIMIT
+                )
+                event_type = 'unit_test_passed' if exec_res.get('passed') else 'unit_test_failed'
+            except asyncio.TimeoutError:
+                logger.warning("Practice execution timed out")
+                event_type = 'unit_test_failed'
+            if cs:
+                try:
+                    await cs.record_event(event_type)
+                except Exception:
+                    logger.exception("Conditioning system failed")
+                    reward.evaluate(event_type)
+            else:
+                reward.evaluate(event_type)
+            logger.info("Practice %s: %s", problem.get('title'), event_type)
+        except Exception:
+            logger.exception("Error in coding practice loop")
+        finally:
+            if iteration_start is not None:
+                elapsed = min(time.time() - iteration_start, _ITERATION_LIMIT)
+                _daily_time_spent += elapsed
+            await asyncio.sleep(60)

--- a/nyx/core/practice/problems.json
+++ b/nyx/core/practice/problems.json
@@ -1,0 +1,4 @@
+[
+  {"title": "Two Sum", "slug": "two-sum", "difficulty": "Easy"},
+  {"title": "Palindrome Number", "slug": "palindrome-number", "difficulty": "Easy"}
+]

--- a/nyx/core/tools/code_executor.py
+++ b/nyx/core/tools/code_executor.py
@@ -1,0 +1,54 @@
+import asyncio
+import os
+import tempfile
+import shutil
+
+
+async def execute_python(code: str, tests: str, timeout: int = 300) -> dict:
+    """Execute Python code and tests using pytest.
+
+    Parameters
+    ----------
+    code : str
+        Source code to execute.
+    tests : str
+        Pytest-style tests importing the code as ``solution``.
+    Returns
+    -------
+    dict
+        Dictionary with 'passed' bool and captured output.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        code_file = os.path.join(tmp, 'solution.py')
+        test_file = os.path.join(tmp, 'test_solution.py')
+        with open(code_file, 'w') as cf:
+            cf.write(code)
+        with open(test_file, 'w') as tf:
+            tf.write(tests)
+        cmd = ['python', '-m', 'pytest', '-q', tmp]
+        timeout_cmd = shutil.which('timeout')
+        if timeout_cmd:
+            cmd = [timeout_cmd, str(timeout)] + cmd
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=tmp
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            proc.kill()
+            stdout, stderr = await proc.communicate()
+            return {
+                'passed': False,
+                'stdout': stdout.decode(),
+                'stderr': 'Timeout',
+                'returncode': -1,
+            }
+        return {
+            'passed': proc.returncode == 0,
+            'stdout': stdout.decode(),
+            'stderr': stderr.decode(),
+            'returncode': proc.returncode,
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,6 +87,7 @@ httpx==0.28.1
 orjson==3.10.18
 python-dateutil==2.8.2
 pytz==2023.3
+psutil==5.9.8
 tenacity==9.1.2
 
 # Other specific versions

--- a/tests/test_code_executor.py
+++ b/tests/test_code_executor.py
@@ -1,0 +1,17 @@
+import pytest
+from nyx.core.tools import code_executor
+
+@pytest.mark.asyncio
+async def test_execute_python_passes():
+    code = "def add(a, b):\n    return a + b"
+    tests = "from solution import add\n\n\ndef test_add():\n    assert add(2, 3) == 5\n"
+    result = await code_executor.execute_python(code, tests)
+    assert result['passed']
+
+
+@pytest.mark.asyncio
+async def test_execute_python_fails():
+    code = "def mul(a, b):\n    return a * b"
+    tests = "from solution import mul\n\n\ndef test_mul():\n    assert mul(2, 3) == 5\n"
+    result = await code_executor.execute_python(code, tests)
+    assert not result['passed']


### PR DESCRIPTION
## Summary
- cleanup reflection logging imports
- adjust coding practice autoloop logic and conditioning recording
- enhance code executor with `python -m pytest` and `timeout`
- bundle problems.json in distribution and add psutil requirement

## Testing
- `PYTHONPATH=. pytest tests/test_code_executor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68472ae742f8832195c3da35059ace85