### PR TITLE
Fix universal updates generation bug

### DIFF
--- a/nyx/nyx_agent_sdk.py
+++ b/nyx/nyx_agent_sdk.py
@@ -2475,9 +2475,13 @@ async def process_user_input(
             # Call generate_universal_updates_impl directly (not the decorated version)
             try:
                 wrapper = RunContextWrapper(context=nyx_context)
+                logger.debug(
+                    "Auto-generating universal updates using %s",
+                    type(generate_universal_updates_impl)
+                )
                 await generate_universal_updates_impl(wrapper, response.narrative)
-            except Exception as e:
-                logger.warning(f"Failed to auto-generate universal updates: {e}")
+            except Exception:
+                logger.exception("Failed to auto-generate universal updates")
         
         # Extract universal updates from context - convert to regular dict for compatibility
         universal_updates_dict = {}
@@ -3101,7 +3105,6 @@ calculate_and_update_emotional_state_impl = calculate_and_update_emotional_state
 manage_beliefs_impl = manage_beliefs
 score_decision_options_impl = score_decision_options
 detect_conflicts_and_instability_impl = detect_conflicts_and_instability
-generate_universal_updates_impl = generate_universal_updates
 
 # Export list for clean imports
 __all__ = [


### PR DESCRIPTION
## Summary
- add debug logging and exception trace when auto-generating universal updates
- remove incorrect compatibility alias that returned a FunctionTool instead of the implementation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'nyx')*

------
https://chatgpt.com/codex/tasks/task_e_689114974cc48321a7e69de5e11fed31