### PR TITLE
Fix agent instantiation after API change

### DIFF
--- a/logic/universal_updater_agent.py
+++ b/logic/universal_updater_agent.py
@@ -1053,7 +1053,6 @@ universal_updater_agent = Agent[UniversalUpdaterContext](
         handoff(extraction_agent, tool_name_override="extract_state_changes")
     ],
     output_type=UniversalUpdateInput,
-    output_schema_strict=False,
     input_guardrails=[
         InputGuardrail(guardrail_function=content_safety_guardrail),
     ],


### PR DESCRIPTION
## Summary
- remove deprecated `output_schema_strict` argument from universal updater agent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nyx', 'memory', 'strategy')*


------
https://chatgpt.com/codex/tasks/task_e_68913b4b11cc8321bfdb963517801f5d