### PR TITLE
Avoid unsupported temperature parameter in OpenAI calls

### DIFF
--- a/context/context_config.py
+++ b/context/context_config.py
@@ -270,18 +270,21 @@ class ContextConfig:
     def get_model_settings(self) -> ModelSettings:
         """
         Get model settings for Agents SDK.
-        
+
         Returns:
             ModelSettings object for the OpenAI Agents SDK
         """
         settings = self.get_section("agent_sdk").get("model_settings", {})
-        return ModelSettings(
-            temperature=settings.get("temperature", 0.1),
-            top_p=settings.get("top_p", 0.9),
-            max_tokens=settings.get("max_tokens", None),
-            presence_penalty=settings.get("presence_penalty", None),
-            frequency_penalty=settings.get("frequency_penalty", None),
-        )
+        kwargs = {
+            "top_p": settings.get("top_p", 0.9),
+            "max_tokens": settings.get("max_tokens", None),
+            "presence_penalty": settings.get("presence_penalty", None),
+            "frequency_penalty": settings.get("frequency_penalty", None),
+        }
+        temperature = settings.get("temperature")
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+        return ModelSettings(**kwargs)
     
     def get_default_model(self) -> str:
         """

--- a/logic/chatgpt_integration.py
+++ b/logic/chatgpt_integration.py
@@ -1816,20 +1816,21 @@ async def _responses_json_call(
     system_prompt: str,
     user_prompt: str,
     max_output_tokens: int = 1024,
-    temperature: float = 0.7,
+    temperature: float | None = None,
 ) -> dict[str, Any]:
     """Call the *Responses* API and return parsed JSON (or raw text fallback)."""
     client = _client_manager.get_responses_client()
-
-    resp = await client.responses.create(
-        model=model,
-        input=[
+    params: dict[str, Any] = {
+        "model": model,
+        "input": [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt},
         ],
-        temperature=temperature,
-        max_output_tokens=max_output_tokens,
-    )
+        "max_output_tokens": max_output_tokens,
+    }
+    if temperature is not None:
+        params["temperature"] = temperature
+    resp = await client.responses.create(**params)
 
     # Accept both new (`output_text`) and legacy (`output`) attributes.
     raw_text = getattr(resp, "output_text", None) or getattr(resp, "output", "")

--- a/logic/memory_logic.py
+++ b/logic/memory_logic.py
@@ -499,7 +499,6 @@ Your response MUST be valid JSON with exactly this structure:
             resp = client.responses.create(
                 model="gpt-5-nano",
                 input=prompt,
-                temperature=0.7,
                 text={"format": {"type": "json_object"}},
             )
 

--- a/memory/emotional.py
+++ b/memory/emotional.py
@@ -312,7 +312,6 @@ class EmotionalMemoryManager:
                     "Return ONLY the JSON object described—no extra text."
                 ),
                 input=prompt,
-                temperature=0.3,
             )
     
             # Parse and validate with Pydantic

--- a/memory/interference.py
+++ b/memory/interference.py
@@ -517,7 +517,6 @@ class MemoryInterferenceManager:
                 model="gpt-5-nano",
                 instructions="You create blended false memories.",
                 input=prompt,
-                temperature=0.7
             )
             return resp.output_text.strip()
         except Exception as e:
@@ -550,7 +549,6 @@ class MemoryInterferenceManager:
                 model="gpt-5-nano",
                 instructions="You create temporally-confused false memories.",
                 input=prompt,
-                temperature=0.7
             )
             return resp.output_text.strip()
     
@@ -590,7 +588,6 @@ class MemoryInterferenceManager:
                 model="gpt-5-nano",
                 instructions="You craft emotionally weighted blended memories.",
                 input=prompt,
-                temperature=0.7
             )
             return resp.output_text.strip()
     
@@ -622,7 +619,6 @@ class MemoryInterferenceManager:
                 model="gpt-5-nano",
                 instructions="You produce generic blended false memories.",
                 input=prompt,
-                temperature=0.7
             )
             return resp.output_text.strip()
     

--- a/memory/managers.py
+++ b/memory/managers.py
@@ -35,7 +35,7 @@ plot_hook_generator = Agent(
     Keep text intriguing. Do not wrap the JSON in markdown fences.
     """,
     model="gpt-5-nano",
-    model_settings=ModelSettings(temperature=0.8))
+    model_settings=ModelSettings())
 
 class NPCMemoryManager(UnifiedMemoryManager):
     """

--- a/memory/memory_agent_sdk.py
+++ b/memory/memory_agent_sdk.py
@@ -487,7 +487,7 @@ def create_memory_agent(user_id: int, conversation_id: int):
         input_guardrails=[
             InputGuardrail(guardrail_function=validate_entity_input)
         ],
-        model_settings=ModelSettings(temperature=0.3),
+        model_settings=ModelSettings(),
         model="gpt-5-nano"
     )
     

--- a/memory/memory_retriever.py
+++ b/memory/memory_retriever.py
@@ -126,14 +126,14 @@ class MemoryRetrieverAgent:
                 raise ValueError("OPENAI_API_KEY environment variable is required for OpenAI")
             
             model_name = self.config.get("openai_model_name", "gpt-5-nano")
-            temperature = self.config.get("temperature", 0.0)  # Low temperature for factual responses
-            
+            temp = self.config.get("temperature")
+
             self.llm = await loop.run_in_executor(
                 None,
                 lambda: ChatOpenAI(
                     model_name=model_name,
-                    temperature=temperature,
-                    openai_api_key=openai_api_key
+                    openai_api_key=openai_api_key,
+                    **({"temperature": temp} if temp is not None else {})
                 )
             )
             
@@ -151,8 +151,8 @@ class MemoryRetrieverAgent:
                 lambda: HuggingFaceHub(
                     repo_id=model_name,
                     huggingfacehub_api_token=hf_token,
-                    model_kwargs={"temperature": 0.1, "max_length": 512}
-                )
+                    model_kwargs={"max_length": 512}
+            )
             )
             
         else:

--- a/memory/reconsolidation.py
+++ b/memory/reconsolidation.py
@@ -418,7 +418,6 @@ class ReconsolidationManager:
                     {"role": "system", "content": "You simulate human memory reconsolidation."},
                     {"role": "user", "content": prompt}
                 ],
-                temperature=0.4,
                 max_tokens=500
             )
             return response.choices[0].message.content.strip()

--- a/memory/schemas.py
+++ b/memory/schemas.py
@@ -293,7 +293,6 @@ class MemorySchemaManager:
                 model="gpt-5-nano",
                 instructions="You detect patterns in memories to form schemas.",
                 input=prompt,
-                temperature=0.4,
                 text={"format": {"type": "json_object"}},
             )
             result = json.loads(resp.output_text)
@@ -824,7 +823,6 @@ class MemorySchemaManager:
                 model="gpt-5-nano",
                 instructions="You rate memory/schema relevance.",
                 input=prompt,
-                temperature=0.1
             )
             score = float(resp.output_text.strip())
             return max(0.0, min(1.0, score))
@@ -1008,7 +1006,6 @@ class MemorySchemaManager:
                 model="gpt-5-nano",
                 instructions="You interpret memories through cognitive schemas.",
                 input=prompt,
-                temperature=0.4
             )
             return resp.output_text.strip()
     
@@ -1177,7 +1174,6 @@ class MemorySchemaManager:
                 model="gpt-5-nano",
                 instructions="You calculate schema/memory conflict.",
                 input=prompt,
-                temperature=0.1
             )
             score = float(resp.output_text.strip())
             return max(0.0, min(1.0, score))
@@ -1214,7 +1210,6 @@ class MemorySchemaManager:
                 model="gpt-5-nano",
                 instructions="You explain memory/schema conflicts.",
                 input=prompt,
-                temperature=0.4
             )
             return resp.output_text.strip()
         except Exception as e:
@@ -1360,7 +1355,6 @@ class MemorySchemaManager:
                 model="gpt-5-nano",
                 instructions="You evolve schemas to handle conflicts.",
                 input=prompt,
-                temperature=0.4,
                 text={"format": {"type": "json_object"}},
             )
             return json.loads(resp.output_text)
@@ -1523,7 +1517,6 @@ class MemorySchemaManager:
                 model="gpt-5-nano",
                 instructions="You merge schemas.",
                 input=prompt,
-                temperature=0.4,
                 text={"format": {"type": "json_object"}},
             )
             return json.loads(resp.output_text)
@@ -1728,7 +1721,6 @@ class MemorySchemaManager:
                 model="gpt-5-nano",
                 instructions="You rate schema similarity.",
                 input=prompt,
-                temperature=0.1,
             )
             score = float(resp.output_text.strip())
             return max(0.0, min(1.0, score))

--- a/memory/semantic.py
+++ b/memory/semantic.py
@@ -178,7 +178,6 @@ class SemanticMemoryManager:
                     {"role": "system", "content": "You extract semantic abstractions from memories."},
                     {"role": "user", "content": prompt}
                 ],
-                temperature=0.4,
                 max_tokens=100
             )
             
@@ -358,7 +357,6 @@ class SemanticMemoryManager:
                     {"role": "system", "content": "You extract patterns from memory clusters."},
                     {"role": "user", "content": prompt}
                 ],
-                temperature=0.3,
                 max_tokens=300
             )
     
@@ -710,7 +708,6 @@ class SemanticMemoryManager:
                     {"role": "system", "content": "You generate counterfactual variations of memories."},
                     {"role": "user", "content": prompt}
                 ],
-                temperature=0.7,
                 max_tokens=200
             )
             
@@ -882,10 +879,9 @@ class SemanticMemoryManager:
                 response = await client.chat.completions.create(
                     model="gpt-5-nano",
                     messages=[
-                        {"role": "system", "content": "You extract related topics from memory text."},
-                        {"role": "user", "content": prompt}
-                    ],
-                    temperature=0.5,
+                    {"role": "system", "content": "You extract related topics from memory text."},
+                    {"role": "user", "content": prompt}
+                ],
                     max_tokens=100
                 )
                 

--- a/npcs/new_npc_creation.py
+++ b/npcs/new_npc_creation.py
@@ -4378,15 +4378,17 @@ class NPCCreationHandler:
         last_err = None
         for attempt in range(3):
             try:
-                resp = await client.responses.create(
-                    model=model,
-                    input=[
+                params = {
+                    "model": model,
+                    "input": [
                         {"role": "system", "content": system_msg},
                         {"role": "user", "content": user_msg},
                     ],
-                    temperature=temperature,
-                    max_output_tokens=max_output_tokens,
-                )
+                    "max_output_tokens": max_output_tokens,
+                }
+                if temperature is not None:
+                    params["temperature"] = temperature
+                resp = await client.responses.create(**params)
     
                 # Preferred convenience accessor (unifies across content parts).
                 text = (resp.output_text or "").strip()

--- a/nyx/core/brain/nyx_distributed_checkpoint.py
+++ b/nyx/core/brain/nyx_distributed_checkpoint.py
@@ -257,14 +257,14 @@ class DistributedCheckpointMixin:
         )
     
         try:
-            resp = await client.responses.create(
-                model="gpt-5-nano",
-                instructions=merge_instr,
-                input=user_input,
-                temperature=0.1,
-                max_tokens=800,
-                text={"format": {"type": "json_object"}},   # force JSON mode
-            )
+            params = {
+                "model": "gpt-5-nano",
+                "instructions": merge_instr,
+                "input": user_input,
+                "max_tokens": 800,
+                "text": {"format": {"type": "json_object"}},  # force JSON mode
+            }
+            resp = await client.responses.create(**params)
             raw_json = json.loads(resp.output_text)
             merged = raw_json.get("merged_state")
             if not isinstance(merged, dict):

--- a/nyx/core/logging/summarizer.py
+++ b/nyx/core/logging/summarizer.py
@@ -23,7 +23,6 @@ async def _summarise(text: str) -> str:
         model=DEFAULT_MODEL,
         instructions=SYSTEM_PROMPT,   # ← old “system” role
         input=text,                   # ← old “user” role
-        temperature=0.3,
         max_tokens=250,
         stream=True,
     )

--- a/nyx/nyx_agent_sdk.py
+++ b/nyx/nyx_agent_sdk.py
@@ -2429,7 +2429,7 @@ Always maintain your dominant persona while being attentive to user needs and sy
     output_type=NarrativeResponse,
     input_guardrails=[InputGuardrail(guardrail_function=content_moderation_guardrail)],
     model="gpt-5-nano",
-    model_settings=ModelSettings(temperature=0.7)
+    model_settings=ModelSettings()
 )
 
 # ===== Main Functions (maintaining original signatures) =====
@@ -3052,7 +3052,7 @@ Remember: You are Nyx, an AI Dominant managing femdom roleplay scenarios. Be con
         output_type=NarrativeResponse,
         input_guardrails=[InputGuardrail(guardrail_function=content_moderation_guardrail)],
         model="gpt-5-nano",
-        model_settings=ModelSettings(temperature=0.7)
+        model_settings=ModelSettings()
     )
 
 async def create_preset_aware_nyx_agent(


### PR DESCRIPTION
## Summary
- Stop sending `temperature` to the Responses API unless explicitly provided
- Remove `temperature` from model settings for memory and Nyx agents
- Strip static temperature arguments from various memory and NPC helper utilities

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'nyx')*


------
https://chatgpt.com/codex/tasks/task_e_6895060f57188321b4416f701eb0781c