### PR TITLE
Introduce RoleplayEngine orchestrator

### DIFF
--- a/logic/roleplay_engine.py
+++ b/logic/roleplay_engine.py
@@ -1,0 +1,69 @@
+import json
+from typing import Any, Dict
+
+from logic.aggregator_sdk import get_aggregated_roleplay_context
+from logic.universal_updater_agent import (
+    UniversalUpdaterContext,
+    apply_universal_updates_async,
+    convert_updates_for_database,
+)
+from db.connection import get_db_connection_context
+
+
+class RoleplayEngine:
+    """Unified orchestrator for roleplay turns.
+
+    This engine retrieves context, generates narrative plus structured
+    updates in a single LLM call, and applies those updates back to the
+    database. The goal is to minimize round trips and keep canon in sync.
+    """
+
+    async def prepare_context(
+        self, user_id: int, conversation_id: int, player_name: str
+    ) -> Dict[str, Any]:
+        """Fetch aggregated context for the current turn."""
+        return await get_aggregated_roleplay_context(
+            user_id, conversation_id, player_name
+        )
+
+    async def generate_turn(
+        self,
+        user_id: int,
+        conversation_id: int,
+        player_name: str,
+        player_input: str,
+    ) -> Dict[str, Any]:
+        """Generate narrative and apply updates for a single turn."""
+        context = await self.prepare_context(user_id, conversation_id, player_name)
+
+        prompt = (
+            "You are the roleplay engine. Using the provided context and "
+            "player input, continue the story and specify any game state "
+            "updates in JSON. Return an object with keys 'narrative' and "
+            "'updates'.\n\n"
+            f"Context: {json.dumps(context)}\n"
+            f"Player Input: {player_input}"
+        )
+        from logic.gpt_utils import call_gpt_json
+
+        result = await call_gpt_json(conversation_id, context, prompt)
+        narrative = result.get("narrative", "")
+        updates = result.get("updates", {})
+
+        if updates:
+            await self.apply_updates(user_id, conversation_id, updates)
+
+        return {"narrative": narrative, "updates": updates}
+
+    async def apply_updates(
+        self, user_id: int, conversation_id: int, updates: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Apply structured updates to the database."""
+        ctx = UniversalUpdaterContext(user_id, conversation_id)
+        await ctx.initialize()
+
+        db_updates = convert_updates_for_database(updates)
+        async with get_db_connection_context() as conn:
+            return await apply_universal_updates_async(
+                ctx, user_id, conversation_id, db_updates, conn
+            )

--- a/tests/test_roleplay_engine.py
+++ b/tests/test_roleplay_engine.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import asyncio
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from logic.roleplay_engine import RoleplayEngine
+
+
+def test_roleplay_engine_generation(monkeypatch):
+    async def fake_context(user_id, conversation_id, player_name):
+        return {"location": "town"}
+
+    async def fake_call_gpt_json(conversation_id, context, prompt, model="gpt-5-nano", temperature=0.7, max_retries=2):
+        assert context["location"] == "town"
+        return {"narrative": "A brave hero arrives.", "updates": {"roleplay_updates": []}}
+
+    async def fake_apply(self, user_id, conversation_id, updates):
+        self.applied = updates
+        return {"success": True}
+
+    import types, sys as _sys
+    _sys.modules["logic.gpt_utils"] = types.SimpleNamespace(
+        call_gpt_json=fake_call_gpt_json
+    )
+
+    monkeypatch.setattr("logic.roleplay_engine.get_aggregated_roleplay_context", fake_context)
+    monkeypatch.setattr(RoleplayEngine, "apply_updates", fake_apply)
+
+    async def run():
+        engine = RoleplayEngine()
+        result = await engine.generate_turn(1, 1, "Player", "Hello")
+        assert result["narrative"] == "A brave hero arrives."
+        assert engine.applied == {"roleplay_updates": []}
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add RoleplayEngine to consolidate context retrieval, narrative generation, and state updates in a single async flow
- add unit test verifying RoleplayEngine integrates context and update application hooks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nyx', etc.)*
- `pytest tests/test_roleplay_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68952295c5308321b5d30d9af362a017