### PR TITLE
Refine strict JSON schema for updater

### DIFF
--- a/logic/aggregator_sdk.py
+++ b/logic/aggregator_sdk.py
@@ -692,10 +692,7 @@ class OptimizedIncrementalContextManager:
         Get the full context without delta tracking.
         """
         context_data = await get_aggregated_roleplay_context(
-            user_id=user_id,
-            conversation_id=conversation_id,
-            current_input=user_input,
-            location=location
+            user_id, conversation_id, player_name="Chase"
         )
         return {
             "full_context": context_data,


### PR DESCRIPTION
## Summary
- Tighten JSON value typing for structured outputs in `universal_updater_agent`
- Fix roleplay update call signature to `canon.update_current_roleplay`
- Correct aggregator context retrieval parameters

## Testing
- `pytest` *(fails: unrecognized arguments; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68954655f8b88321ac3250729235f2ab