### PR TITLE
Remove unsupported temperature parameter from lore validation agent

### DIFF
--- a/lore/systems/dynamics.py
+++ b/lore/systems/dynamics.py
@@ -477,7 +477,7 @@ class LoreDynamicsSystem(BaseLoreManager):
                 "narrative elements that can drive lore evolution."
             ),
             model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.8),
+            model_settings=ModelSettings(),
             output_type=EventValidation
         )
         


### PR DESCRIPTION
## Summary
- Avoid passing the `temperature` argument in lore event validation to prevent API errors with models that don't support it.

## Testing
- `pytest tests/unit/test_npc_system.py -q` *(fails: ModuleNotFoundError: No module named 'npcs')*

------
https://chatgpt.com/codex/tasks/task_e_6895a88b7a788321b13c6c8cfbf255b2