### PR TITLE
Add robust updater tool invocation and skeleton fallback

### DIFF
--- a/logic/time_cycle.py
+++ b/logic/time_cycle.py
@@ -2235,7 +2235,7 @@ async def set_current_time(user_id, conversation_id, new_year, new_month, new_da
                 ("CurrentDay", str(new_day)),
                 ("TimeOfDay", new_phase),
             ]:
-                await canon.update_current_roleplay(canon_ctx, conn, user_id, conversation_id, key, val)
+                await canon.update_current_roleplay(canon_ctx, conn, key, str(val))
     except (asyncpg.PostgresError, ConnectionError, asyncio.TimeoutError) as e:
         logger.error(f"Database error setting current time: {e}", exc_info=True)
     except Exception as e:


### PR DESCRIPTION
## Summary
- Add SDK-agnostic `_invoke_function_tool` helper and minimal `_build_min_skeleton` payload
- Strengthen JSON handling in `apply_universal_updates` and `process_universal_update`
- Fix `canon.update_current_roleplay` invocation in `time_cycle.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'memory'; ModuleNotFoundError: No module named 'nyx'; RuntimeError: OPENAI_API_KEY not found in environment; requests.exceptions.ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_6896231999c483219f1a7fb9cf399106