### PR TITLE
Use game time in memory telemetry

### DIFF
--- a/memory/core.py
+++ b/memory/core.py
@@ -348,6 +348,8 @@ def with_transaction(func):
                     
                     elapsed = time.time() - start_time
                     await MemoryTelemetry.record(
+                        self.user_id,
+                        self.conversation_id,
                         operation=func.__name__,
                         success=True,
                         duration=elapsed,
@@ -359,6 +361,8 @@ def with_transaction(func):
                     
                     elapsed = time.time() - start_time
                     await MemoryTelemetry.record(
+                        self.user_id,
+                        self.conversation_id,
                         operation=func.__name__,
                         success=False,
                         duration=elapsed,
@@ -374,6 +378,8 @@ def with_transaction(func):
                 
                 elapsed = time.time() - start_time
                 await MemoryTelemetry.record(
+                    self.user_id,
+                    self.conversation_id,
                     operation=func.__name__,
                     success=True,
                     duration=elapsed,
@@ -383,6 +389,8 @@ def with_transaction(func):
             except Exception as e:
                 elapsed = time.time() - start_time
                 await MemoryTelemetry.record(
+                    self.user_id,
+                    self.conversation_id,
                     operation=func.__name__,
                     success=False,
                     duration=elapsed,

--- a/memory/maintenance.py
+++ b/memory/maintenance.py
@@ -82,6 +82,8 @@ class MemoryMaintenance:
                 stats["duration_seconds"] = duration
                 
                 await MemoryTelemetry.record(
+                    0,
+                    0,
                     operation="memory_cleanup",
                     success=True,
                     duration=duration,
@@ -97,6 +99,8 @@ class MemoryMaintenance:
         except Exception as e:
             logger.error(f"Error during memory cleanup: {e}")
             await MemoryTelemetry.record(
+                0,
+                0,
                 operation="memory_cleanup",
                 success=False,
                 error=str(e)

--- a/memory/wrapper.py
+++ b/memory/wrapper.py
@@ -3,7 +3,8 @@
 import logging
 import asyncio
 from typing import Dict, Any, List, Optional, Union
-from datetime import datetime
+
+from logic.game_time_helper import get_game_datetime, get_game_iso_string
 
 from .integrated import IntegratedMemorySystem, init_memory_system
 from .core import Memory, MemoryType, MemorySignificance


### PR DESCRIPTION
## Summary
- replace realtime datetime tracking with game time helpers in memory telemetry
- propagate user and conversation IDs for telemetry logging
- adjust wrappers and maintenance calls for new telemetry signature

## Testing
- `pytest` *(fails: ProxyError for huggingface.co and missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_689e3ac7051083218c4119ae242823b9