### PR TITLE
Use game time for relationship interactions

### DIFF
--- a/logic/stats_logic.py
+++ b/logic/stats_logic.py
@@ -1000,7 +1000,12 @@ async def check_relationship_milestones(user_id: int, conversation_id: int, play
                 """, player_name, "Bond Token")
                 
                 # Log in relationship history
-                state.history.add_interaction("milestone", "high_trust_affection")
+                await state.history.record_interaction(
+                    user_id,
+                    conversation_id,
+                    "milestone",
+                    "high_trust_affection",
+                )
 # ============================
 # HUNGER & VITALS SYSTEM
 # ============================


### PR DESCRIPTION
## Summary
- track relationship interactions using in-game time with `record_interaction`
- log high-trust milestones with game-time metadata

## Testing
- `pytest` *(fails: requests.exceptions.ProxyError: Cannot connect to proxy huggingface.co)*

------
https://chatgpt.com/codex/tasks/task_e_689e434b8f9c8321a28c6def366ea74d