### PR TITLE
Add game time aware event logging helper

### DIFF
--- a/logic/event_logging.py
+++ b/logic/event_logging.py
@@ -1,0 +1,16 @@
+async def log_event(user_id, conversation_id, event_type, data):
+    from logic.game_time_helper import GameTimeContext
+    async with GameTimeContext(user_id, conversation_id) as game_time:
+        event = {
+            "event_type": event_type,
+            "timestamp": await game_time.to_datetime(),
+            "game_time": {
+                "year": game_time.year,
+                "month": game_time.month,
+                "day": game_time.day,
+                "time_of_day": game_time.time_of_day,
+            },
+            "time_string": await game_time.to_string(),
+            **data,
+        }
+    return event

--- a/nyx/core/agents/base_runner.py
+++ b/nyx/core/agents/base_runner.py
@@ -10,8 +10,15 @@ class OrchestratorMixin:
         self,
         event_type: str,
         payload: dict | None = None,
+        user_id: int | None = None,
+        conversation_id: int | None = None,
     ) -> float:
-        return await orchestrator.log_and_score(event_type, payload)
+        return await orchestrator.log_and_score(
+            event_type,
+            payload,
+            user_id=user_id,
+            conversation_id=conversation_id,
+        )
 
     def start_background(self) -> None:
         orchestrator.start_background()

--- a/tests/test_event_logging.py
+++ b/tests/test_event_logging.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+import types
+from datetime import datetime
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+dummy = types.ModuleType("logic.game_time_helper")
+
+
+class DummyGameTimeContext:
+    def __init__(self, user_id, conversation_id):
+        self.year = 2
+        self.month = 3
+        self.day = 4
+        self.time_of_day = "Evening"
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    async def to_datetime(self):
+        return datetime(2000, 1, 1)
+
+    async def to_string(self, include_date=True, include_time=True):
+        return "dummy"
+
+
+dummy.GameTimeContext = DummyGameTimeContext
+sys.modules["logic.game_time_helper"] = dummy
+
+from logic import event_logging
+
+@pytest.mark.asyncio
+async def test_log_event(monkeypatch):
+    event = await event_logging.log_event(1, 1, "test", {"foo": "bar"})
+    assert event["event_type"] == "test"
+    assert event["game_time"] == {"year": 2, "month": 3, "day": 4, "time_of_day": "Evening"}
+    assert "time_string" in event
+    assert event["foo"] == "bar"


### PR DESCRIPTION
## Summary
- add `log_event` helper to include game time metadata in event payloads
- allow orchestrator to build timestamped events when user and conversation IDs are supplied
- expose user and conversation IDs in orchestrator runner mixin
- add unit test for event logging helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'nyx')*
- `pytest tests/test_event_logging.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e4354082c8321959995cadeaa699b