### PR TITLE
Use lazy game time imports to break circular dependency

### DIFF
--- a/memory/wrapper.py
+++ b/memory/wrapper.py
@@ -4,8 +4,6 @@ import logging
 import asyncio
 from typing import Dict, Any, List, Optional, Union, TYPE_CHECKING
 
-from logic.game_time_helper import get_game_datetime, get_game_iso_string
-
 # Type checking imports (don't cause circular imports)
 if TYPE_CHECKING:
     from .integrated import IntegratedMemorySystem
@@ -24,6 +22,7 @@ _managers_module = None
 _masks_module = None
 _emotional_module = None
 _flashbacks_module = None
+_game_time_helper_module = None
 
 
 def _lazy_import_integrated():
@@ -72,6 +71,14 @@ def _lazy_import_flashbacks():
     if _flashbacks_module is None:
         from . import flashbacks as _flashbacks_module
     return _flashbacks_module
+
+
+def _lazy_import_game_time_helper():
+    """Lazy import for game time helper to avoid circular imports."""
+    global _game_time_helper_module
+    if _game_time_helper_module is None:
+        from logic import game_time_helper as _game_time_helper_module
+    return _game_time_helper_module
 
 
 class MemorySystem:


### PR DESCRIPTION
## Summary
- load game time helper functions lazily in `memory.wrapper`
- defer game time helper imports in `memory.memory_orchestrator` and update methods to use the lazy loader

## Testing
- `pytest test_socketio_app.py` (fails: KeyboardInterrupt)

------
https://chatgpt.com/codex/tasks/task_e_68aab5f6a254832183552d62f57a4bd7