### PR TITLE
Fix mask module import in memory orchestrator

### DIFF
--- a/memory/memory_orchestrator.py
+++ b/memory/memory_orchestrator.py
@@ -493,7 +493,7 @@ class MemoryOrchestrator:
             )
 
             # Mask manager (LEGACY; basic masking)
-            from memory.mask import MaskManager
+            from memory.masks import MaskManager
             self.mask_manager = MaskManager(
                 user_id=self.user_id,
                 conversation_id=self.conversation_id


### PR DESCRIPTION
## Summary
- fix incorrect import of `MaskManager` to use `memory.masks`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'memory'; ProxyError: HTTPSConnectionPool ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bb57516ecc832184de113d35886b2f