### PR TITLE
Fix memory type normalization for unified memories

### DIFF
--- a/memory/integrated.py
+++ b/memory/integrated.py
@@ -8,7 +8,13 @@ import numpy as np
 from datetime import datetime
 from typing import Dict, Any, List, Optional, Union
 
-from .core import Memory, MemoryType, MemorySignificance, UnifiedMemoryManager
+from .core import (
+    Memory,
+    MemoryType,
+    MemorySignificance,
+    UnifiedMemoryManager,
+    normalize_memory_type,
+)
 from .schemas import MemorySchemaManager
 from .emotional import EmotionalMemoryManager
 from .interference import MemoryInterferenceManager
@@ -239,9 +245,13 @@ class IntegratedMemorySystem:
                     default=50
                 )
                 
+                normalized_type = normalize_memory_type(
+                    memory_kwargs.get("memory_type")
+                )
+
                 memory = Memory(
                     text=memory_text,
-                    memory_type=memory_kwargs.get("memory_type", MemoryType.OBSERVATION),
+                    memory_type=normalized_type,
                     significance=memory_kwargs.get("significance", MemorySignificance.MEDIUM),
                     emotional_intensity=emotional_intensity,
                     tags=memory_kwargs.get("tags", []),

--- a/memory/memory_orchestrator.py
+++ b/memory/memory_orchestrator.py
@@ -1430,17 +1430,26 @@ class MemoryOrchestrator:
             md["is_canon"] = True
             md["canonical"] = True
         
+        memory_kwargs = {
+            "significance": significance,
+            "emotional_intensity": emotional_intensity,
+            "tags": tags or [],
+            "metadata": md,
+        }
+
+        if memory_type is not None:
+            if isinstance(memory_type, str):
+                trimmed = memory_type.strip()
+                if trimmed:
+                    memory_kwargs["memory_type"] = trimmed
+            else:
+                memory_kwargs["memory_type"] = memory_type
+
         return await self.integrated_add_memory(
             entity_type=entity_type,
             entity_id=entity_id,
             memory_text=text,  # integrated_add_memory uses memory_text
-            memory_kwargs={
-                "memory_type": memory_type,
-                "significance": significance,
-                "emotional_intensity": emotional_intensity,
-                "tags": tags or [],
-                "metadata": md
-            }
+            memory_kwargs=memory_kwargs,
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary
- normalize memory type inputs so unified memory inserts always persist a valid type
- extend MemoryType enum and orchestrator plumbing to recognize lore/event/relationship tags while skipping null values
- ensure integrated memory creation reuses the normalization logic before calling the core manager

## Testing
- `pytest -o addopts='' tests/test_memory_injection.py` *(fails: missing pytest-asyncio plugin in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2ee68a14832196fac5ae5b32bd6a