### PR TITLE
Fix feasibility guardrails and affordance logging

### DIFF
--- a/nyx/feas/__init__.py
+++ b/nyx/feas/__init__.py
@@ -1,0 +1,1 @@
+"""Feasibility helpers for mundane action evaluation and archetype composition."""

--- a/nyx/feas/actions/__init__.py
+++ b/nyx/feas/actions/__init__.py
@@ -1,0 +1,4 @@
+"""Exports for mundane feasibility actions."""
+
+from .mundane import evaluate_mundane  # noqa: F401
+from .trade import evaluate_buy, price_estimate  # noqa: F401

--- a/nyx/feas/actions/mundane.py
+++ b/nyx/feas/actions/mundane.py
@@ -1,0 +1,32 @@
+"""General mundane action evaluators."""
+from typing import Any, Dict
+
+from .trade import evaluate_buy
+
+
+def evaluate_mundane(intent: Dict[str, Any], world_caps: Dict[str, Any], idx: Dict[str, Any], scene: Dict[str, Any], player: Dict[str, Any]) -> Dict[str, Any]:
+    """Handle everyday actions with gentle guidance defaults."""
+
+    categories = {c.lower() for c in intent.get("categories", [])}
+    if "trade" in categories:
+        return evaluate_buy(intent, world_caps, idx, scene, player)
+
+    prohibitions = {p.lower() for p in world_caps.get("prohibitions", set())}
+    if categories & prohibitions:
+        return {
+            "feasible": False,
+            "strategy": "deny",
+            "violations": [
+                {
+                    "rule": "established_impossibility",
+                    "reason": "The merged archetypes prohibit this mundane action.",
+                }
+            ],
+        }
+
+    description = intent.get("raw_text") or intent.get("verb") or "action"
+    return {
+        "feasible": True,
+        "strategy": "allow",
+        "narrator_guidance": f"You carry out the mundane action: {description}.",
+    }

--- a/nyx/feas/actions/trade.py
+++ b/nyx/feas/actions/trade.py
@@ -1,0 +1,125 @@
+"""Trade action evaluation helpers."""
+from typing import Any, Dict, List
+
+
+def price_estimate(item_name: str, world_caps: Dict[str, Any], scene: Dict[str, Any]) -> Dict[str, Any]:
+    """Very small heuristic price estimator used when catalogs are unavailable."""
+
+    economy = world_caps.get("economy", {})
+    currency = "credits" if economy.get("credits") else "denarii"
+    amount = 1 if item_name and "gum" in item_name.lower() else 5
+    return {"currency": currency, "amount": amount}
+
+
+def evaluate_buy(
+    intent: Dict[str, Any],
+    world_caps: Dict[str, Any],
+    idx: Dict[str, Any],
+    scene: Dict[str, Any],
+    player: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Evaluate a mundane "buy" intent with contextual nudges."""
+
+    if "trade" in world_caps.get("prohibitions", set()):
+        return _deny("Trading is impossible in this setting.")
+
+    if not idx.get("trade_supported", False):
+        analog_loc = idx.get("analogs", {}).get("24h_convenience_store") or idx.get("analogs", {}).get("market_square")
+        if analog_loc:
+            return _analog(f"Try the {analog_loc}.", {"redirect_location_type": analog_loc})
+        return _defer(
+            "Trading isn’t established here. Try heading to a market or commissary nearby.",
+            leads=_nearby_leads(idx),
+        )
+
+    if not idx.get("in_shop", False):
+        leads = _nearby_leads(idx)
+        if leads:
+            return _defer("You’re not in a shop. Nearest options:", leads=leads)
+        analog_loc = idx.get("analogs", {}).get("market_square") or idx.get("analogs", {}).get("habitat_commissary")
+        if analog_loc:
+            return _defer(f"Find a {analog_loc} to buy that.", leads=[{"kind": "district", "name": analog_loc}])
+        return _defer("No vendor here—look for a market, stall, or vendor first.")
+
+    direct_object = intent.get("direct_object") or ["item"]
+    item = direct_object[0]
+    estimate = price_estimate(item, world_caps, scene)
+
+    if not idx.get("has_currency", False):
+        if world_caps.get("economy", {}).get("bartering_ok"):
+            return _allow(f"You can barter for {item}. Offer an item of similar value.")
+        return _defer(f"You need currency to buy {item}.", leads=_nearby_atm_or_exchange(scene))
+
+    balance = idx.get("balance", {}).get(estimate["currency"], 0)
+    if balance < estimate["amount"]:
+        return _defer(
+            f"Price ~{estimate['amount']} {estimate['currency']}, you have {balance}.",
+            leads=[{"kind": "earn", "name": "Take a small job"}, {"kind": "exchange", "name": "Currency exchange"}],
+        )
+
+    return _allow(
+        f"You purchase {item} for {estimate['amount']} {estimate['currency']}.",
+        modifications={
+            "inventory_add": [item],
+            "currency_debit": {estimate["currency"]: estimate["amount"]},
+        },
+    )
+
+
+def _allow(msg: str, modifications: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    return {
+        "feasible": True,
+        "strategy": "allow",
+        "narrator_guidance": msg,
+        "modifications": modifications or {},
+    }
+
+
+def _defer(msg: str, leads: Any | None = None) -> Dict[str, Any]:
+    return {
+        "feasible": False,
+        "strategy": "defer",
+        "narrator_guidance": msg,
+        "leads": leads or [],
+    }
+
+
+def _analog(msg: str, modifications: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    return {
+        "feasible": False,
+        "strategy": "analog",
+        "narrator_guidance": msg,
+        "modifications": modifications or {},
+    }
+
+
+def _deny(msg: str) -> Dict[str, Any]:
+    return {
+        "feasible": False,
+        "strategy": "deny",
+        "violations": [{"rule": "established_impossibility", "reason": msg}],
+    }
+
+
+def _nearby_leads(idx: Dict[str, Any]) -> Any:
+    leads: List[Dict[str, Any]] = []
+    for entry in idx.get("nearby_shops", [])[:3]:
+        if isinstance(entry, dict):
+            leads.append(
+                {
+                    "kind": "shop",
+                    "name": entry.get("name"),
+                    "dist_m": entry.get("dist_m"),
+                }
+            )
+        else:
+            try:
+                _identifier, name, dist = entry
+            except Exception:
+                continue
+            leads.append({"kind": "shop", "name": name, "dist_m": dist})
+    return leads
+
+
+def _nearby_atm_or_exchange(scene: Dict[str, Any]) -> Any:
+    return scene.get("nearby", {}).get("exchanges", []) or []

--- a/nyx/feas/archetypes/__init__.py
+++ b/nyx/feas/archetypes/__init__.py
@@ -1,0 +1,3 @@
+"""Archetype registry exports."""
+
+from .base import Archetype, ArchetypeCaps  # noqa: F401

--- a/nyx/feas/archetypes/base.py
+++ b/nyx/feas/archetypes/base.py
@@ -1,0 +1,26 @@
+"""Base definitions for feasibility archetypes."""
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+
+@dataclass
+class ArchetypeCaps:
+    """Small bundle of capabilities supplied by an archetype module."""
+
+    infra: Dict[str, bool] = field(default_factory=dict)
+    economy: Dict[str, bool] = field(default_factory=dict)
+    affordances: Set[str] = field(default_factory=set)
+    prohibitions: Set[str] = field(default_factory=set)
+    analogs: Dict[str, str] = field(default_factory=dict)
+    weights: Dict[str, float] = field(default_factory=dict)
+
+
+class Archetype:
+    """Interface for capability archetypes."""
+
+    name: str
+
+    def caps(self) -> ArchetypeCaps:
+        """Return the capability contribution from this archetype."""
+
+        raise NotImplementedError

--- a/nyx/feas/archetypes/modern_baseline.py
+++ b/nyx/feas/archetypes/modern_baseline.py
@@ -1,0 +1,32 @@
+"""Neutral modern-day archetype used as fallback."""
+
+from .base import Archetype, ArchetypeCaps
+
+
+class ModernBaseline(Archetype):
+    """Provides permissive defaults for contemporary settings."""
+
+    name = "modern_baseline"
+
+    def caps(self) -> ArchetypeCaps:
+        return ArchetypeCaps(
+            infra={
+                "electricity": True,
+                "printing": True,
+                "instant_comms": True,
+                "plumbing": True,
+                "global_trade": True,
+            },
+            economy={
+                "has_currency": True,
+                "bartering_ok": True,
+                "markets_common": True,
+                "credits": False,
+            },
+            affordances={"mundane_action", "trade", "movement", "social"},
+            prohibitions=set(),
+            analogs={
+                "market_square": "shopping_district",
+                "24h_convenience_store": "24h_convenience_store",
+            },
+        )

--- a/nyx/feas/archetypes/roman_empire.py
+++ b/nyx/feas/archetypes/roman_empire.py
@@ -1,0 +1,30 @@
+"""Roman Empire inspired capability archetype."""
+
+from .base import Archetype, ArchetypeCaps
+
+
+class RomanEmpire(Archetype):
+    """Classical Roman-era baseline."""
+
+    name = "roman_empire"
+
+    def caps(self) -> ArchetypeCaps:
+        return ArchetypeCaps(
+            infra={
+                "printing": False,
+                "electricity": False,
+                "plumbing": True,
+                "global_trade": True,
+            },
+            economy={
+                "has_currency": True,
+                "bartering_ok": True,
+                "markets_common": True,
+            },
+            affordances={"mundane_action", "trade", "movement", "social"},
+            prohibitions={"firearm_use", "microprocessors", "instant_comms"},
+            analogs={
+                "24h_convenience_store": "market_square",
+                "phone": "letter",
+            },
+        )

--- a/nyx/feas/archetypes/underwater_scifi.py
+++ b/nyx/feas/archetypes/underwater_scifi.py
@@ -1,0 +1,33 @@
+"""Futuristic underwater habitat archetype."""
+
+from .base import Archetype, ArchetypeCaps
+
+
+class UnderwaterSciFi(Archetype):
+    """Supports high-tech underwater settlements."""
+
+    name = "underwater_scifi"
+
+    def caps(self) -> ArchetypeCaps:
+        return ArchetypeCaps(
+            infra={
+                "electricity": True,
+                "printing": True,
+                "instant_comms": True,
+                "airlock": True,
+            },
+            economy={
+                "has_currency": True,
+                "markets_common": False,
+                "credits": True,
+            },
+            affordances={
+                "mundane_action",
+                "trade",
+                "movement",
+                "social",
+                "vehicle_operation_water",
+            },
+            prohibitions=set(),
+            analogs={"market_square": "habitat_commissary"},
+        )

--- a/nyx/feas/capabilities.py
+++ b/nyx/feas/capabilities.py
@@ -1,0 +1,31 @@
+"""Capability composition helpers for feasibility."""
+from typing import Any, Dict, Iterable
+
+from .archetypes.base import ArchetypeCaps
+
+
+def merge_caps(arche_caps: Iterable[ArchetypeCaps]) -> Dict[str, Any]:
+    """Merge capability contributions from multiple archetypes."""
+
+    combined: Dict[str, Any] = {
+        "infra": {},
+        "economy": {},
+        "affordances": set(),
+        "prohibitions": set(),
+        "analogs": {},
+        "weights": {},
+    }
+
+    for caps in arche_caps:
+        # Merge infra/economy booleans using logical OR semantics.
+        for key, value in caps.infra.items():
+            combined["infra"][key] = combined["infra"].get(key, False) or bool(value)
+        for key, value in caps.economy.items():
+            combined["economy"][key] = combined["economy"].get(key, False) or bool(value)
+
+        combined["affordances"].update(caps.affordances)
+        combined["prohibitions"].update(caps.prohibitions)
+        combined["analogs"].update(caps.analogs)
+        combined["weights"].update(caps.weights)
+
+    return combined

--- a/nyx/feas/context.py
+++ b/nyx/feas/context.py
@@ -1,0 +1,31 @@
+"""Context helpers for mundane feasibility evaluation."""
+from typing import Any, Dict
+
+
+def build_affordance_index(world_caps: Dict[str, Any], scene: Dict[str, Any], player: Dict[str, Any]) -> Dict[str, Any]:
+    """Derive quick affordance checks from world, scene, and player state."""
+
+    location_tags = scene.get("location_tags") or []
+    nearby = scene.get("nearby") or {}
+
+    idx = {
+        "in_shop": bool(location_tags.count("shop") > 0 or scene.get("has_vendor")),
+        "nearby_shops": nearby.get("shops", []),
+        "open_shop": bool(scene.get("open_shop")),
+    }
+
+    if world_caps.get("economy", {}).get("has_currency"):
+        balance = player.get("currency", {})
+        idx["has_currency"] = any(balance.values()) if isinstance(balance, dict) else False
+    else:
+        idx["has_currency"] = bool(world_caps.get("economy", {}).get("bartering_ok"))
+
+    idx["balance"] = player.get("currency", {}) if isinstance(player.get("currency"), dict) else {}
+    idx["age_ok"] = player.get("age_ok", True)
+    idx["reputation"] = player.get("reputation", 0)
+    affordances = world_caps.get("affordances", set())
+    prohibitions = world_caps.get("prohibitions", set())
+    idx["trade_supported"] = "trade" in affordances and "trade" not in prohibitions
+    idx["analogs"] = world_caps.get("analogs", {})
+    idx["infra"] = world_caps.get("infra", {})
+    return idx


### PR DESCRIPTION
## Summary
- normalize the world context fetch by fixing the SettingEra key list and computing the caps_loaded flag safely when deriving feasibility capabilities
- broaden trade affordance handling so evaluate_buy has a clear signature and nearby lead extraction tolerates dict or tuple scene inputs

## Testing
- python -m compileall nyx/feas nyx/nyx_agent/feasibility.py lore/core/gate_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68cda47d0a6883219687927bfef4354c