### PR TITLE
Queue NPC creation in background to maintain NPC pool

### DIFF
--- a/celery_config.py
+++ b/celery_config.py
@@ -93,6 +93,7 @@ task_routes = {
     # High priority tasks
     'tasks.process_new_game_task': {'queue': 'high'},
     'tasks.create_npcs_task': {'queue': 'high'},
+    'tasks.ensure_npc_pool_task': {'queue': 'high'},
     'tasks.background_chat_task_with_memory': {'queue': 'high'},
     
     # Default priority tasks


### PR DESCRIPTION
## Summary
- generate Chase's schedule during new game setup and enqueue NPC background creation instead of blocking the pipeline
- persist NPC pool status in CurrentRoleplay and relax readiness checks to allow queued generation while still requiring world data
- add a Celery task that tops up the NPC pool asynchronously and route it to the high-priority queue

## Testing
- pytest tests/unit *(fails: huggingface download blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc3849118832194a21a3d92bffa84