### PR TITLE
Update new game endpoints in chat page

### DIFF
--- a/static/chat_page.js
+++ b/static/chat_page.js
@@ -553,7 +553,7 @@ window.startNewGame = async function() {
   chatWindow.scrollTop = chatWindow.scrollHeight;
 
   try {
-    const data = await fetchJson("/start_new_game", {
+    const data = await fetchJson("/new_game/start_new_game", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({})


### PR DESCRIPTION
## Summary
- point the new game creation request in chat_page.js to the /new_game/start_new_game endpoint
- confirm the pollForGameReady helper continues to query the /new_game/conversation_status endpoint when waiting for completion

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdf8f5d9cc8321ba76a2ecdc4c25ea