### PR TITLE
Update Celery routing to use background queue

### DIFF
--- a/celery_config.py
+++ b/celery_config.py
@@ -90,11 +90,11 @@ QUEUE_PRIORITIES = {
 
 # Task routing based on priority
 task_routes = {
-    # High priority tasks
-    'tasks.process_new_game_task': {'queue': 'high'},
-    'tasks.create_npcs_task': {'queue': 'high'},
-    'tasks.ensure_npc_pool_task': {'queue': 'high'},
-    'tasks.background_chat_task_with_memory': {'queue': 'high'},
+    # Background processing tasks
+    'tasks.process_new_game_task': {'queue': 'background'},
+    'tasks.create_npcs_task': {'queue': 'background'},
+    'tasks.ensure_npc_pool_task': {'queue': 'background'},
+    'tasks.background_chat_task_with_memory': {'queue': 'background'},
     
     # Default priority tasks
     'tasks.run_npc_learning_cycle_task': {'queue': 'default'},


### PR DESCRIPTION
## Summary
- route the Celery tasks that previously targeted the "high" queue to the existing `background` queue so workers consume them
- keep routing for other task priorities unchanged while relying on the nyx queue definitions already provided

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cfac5af9e083219b8141e50651c4d1