### PR TITLE
Ensure redis config includes task routes

### DIFF
--- a/celery_config.py
+++ b/celery_config.py
@@ -178,8 +178,9 @@ if USE_RABBITMQ:
     }
     celery_app.conf.update({**base_config, **rabbitmq_config})
 else:
-    # Simpler configuration for Redis
-    celery_app.conf.update(base_config)
+    # Simpler configuration for Redis while ensuring task routes are configured
+    redis_config = {**base_config, 'task_routes': task_routes}
+    celery_app.conf.update(redis_config)
 
 
 def _merge_task_queues():


### PR DESCRIPTION
## Summary
- ensure the Redis-specific Celery configuration applies the shared task route mappings so background tasks remain routed

## Testing
- python - <<'PY'
from celery_config import celery_app, task_routes

print('task_routes configured:', celery_app.conf.task_routes)
print('process_new_game_task queue:', celery_app.conf.task_routes.get('tasks.process_new_game_task'))
PY

------
https://chatgpt.com/codex/tasks/task_e_68d0450260c48321b287ede369ab3ee2