### PR TITLE
Route new game background generators to background queue

### DIFF
--- a/celery_config.py
+++ b/celery_config.py
@@ -95,7 +95,9 @@ task_routes = {
     'tasks.create_npcs_task': {'queue': 'background'},
     'tasks.ensure_npc_pool_task': {'queue': 'background'},
     'tasks.background_chat_task_with_memory': {'queue': 'background'},
-    
+    'tasks.generate_lore_background_task': {'queue': 'background'},
+    'tasks.generate_initial_conflict_task': {'queue': 'background'},
+
     # Default priority tasks
     'tasks.run_npc_learning_cycle_task': {'queue': 'default'},
     'tasks.nyx_memory_maintenance_task': {'queue': 'default'},


### PR DESCRIPTION
## Summary
- route the lore and initial conflict background generation tasks to the background queue so they run on the correct worker

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'memory'; ModuleNotFoundError: No module named 'nyx'; ImportError: cannot import name 'get_game_datetime' from 'logic.game_time_helper')*


------
https://chatgpt.com/codex/tasks/task_e_68d04be036308321959c9dc6a17e04c1