### PR TITLE
Handle asyncpg records when hydrating preset NPCs

### DIFF
--- a/new_game_agent.py
+++ b/new_game_agent.py
@@ -2576,7 +2576,16 @@ class NewGameAgent:
 
         npc_id = None
         if row:
-            npc_id = row.get("npc_id") if isinstance(row, dict) else row[0]
+            if isinstance(row, dict):
+                npc_id = row.get("npc_id")
+            else:
+                try:
+                    npc_id = row["npc_id"]
+                except (TypeError, KeyError):
+                    try:
+                        npc_id = row[0]
+                    except (TypeError, IndexError):
+                        npc_id = None
 
         if npc_id is None:
             logger.warning("Failed to obtain NPC id for preset NPC %s", npc_name)


### PR DESCRIPTION
## Summary
- ensure `_hydrate_preset_npc_records` reads asyncpg-style return values without relying on `.get`
- update the preset new game stub connection to emit record-like rows for NPC inserts and capture results
- assert the fast-path preset flow still persists each NPC when record-like rows are returned

## Testing
- pytest --override-ini addopts="" tests/test_new_game_agent_preset.py


------
https://chatgpt.com/codex/tasks/task_e_68d41d8711908321804879eb06fc06a2