### PR TITLE
Remove temperature overrides for gpt-5-nano lore agents

### DIFF
--- a/lore/core/cache.py
+++ b/lore/core/cache.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 import json
 import logging
 
-from agents import Agent, function_tool, Runner, trace, ModelSettings
+from agents import Agent, function_tool, Runner, trace
 from agents.run import RunConfig
 
 @dataclass
@@ -88,8 +88,7 @@ class LoreCache:
                 "cache misses, suggesting priority adjustments, and predicting "
                 "which items should be pre-warmed."
             ),
-            model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.0)
+            model="gpt-5-nano"
         )
     
     async def get(self, namespace, key, user_id=None, conversation_id=None):

--- a/lore/frameworks/matriarchal.py
+++ b/lore/frameworks/matriarchal.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel, Field
 # Agents SDK imports
 from agents import (
     Agent,
-    ModelSettings,
     Runner,
     function_tool,
     handoff,
@@ -111,7 +110,6 @@ class MatriarchalPowerStructureFramework(BaseLoreManager):
                 "women hold most or all power, and men occupy subordinate or service-based roles."
             ),
             model="gpt-5-nano",  # Using valid model name
-            model_settings=ModelSettings(temperature=0.9)
         )
         
         # Initialize specialized narrative transformation agents
@@ -125,7 +123,6 @@ class MatriarchalPowerStructureFramework(BaseLoreManager):
                 "consistency, and engagement. Provide constructive feedback for improvements."
             ),
             model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.5),
             output_type=NarrativeEvaluation
         )
 
@@ -139,8 +136,7 @@ class MatriarchalPowerStructureFramework(BaseLoreManager):
                 "Focus on governance, authority, and policy formation led by women, with men in advisory "
                 "or supportive roles only."
             ),
-            model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.9)
+            model="gpt-5-nano"
         )
         
         # Religious narrative specialist
@@ -151,8 +147,7 @@ class MatriarchalPowerStructureFramework(BaseLoreManager):
                 "Create matriarchal religious structures with goddesses as primary deities and "
                 "priestesses as the dominant religious authorities."
             ),
-            model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.9)
+            model="gpt-5-nano"
         )
         
         # Social/cultural narrative specialist
@@ -163,8 +158,7 @@ class MatriarchalPowerStructureFramework(BaseLoreManager):
                 "Create customs, traditions, and social interactions that reinforce feminine authority "
                 "and masculine deference."
             ),
-            model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.9)
+            model="gpt-5-nano"
         )
         
         # Configure agent handoffs
@@ -569,8 +563,7 @@ class MatriarchalPowerStructureFramework(BaseLoreManager):
                 "Continue from the existing narrative, adding new developments, "
                 "conflicts, or revelations."
             ),
-            model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.9)
+            model="gpt-5-nano"
         )
         
         character_agent = Agent(
@@ -580,8 +573,7 @@ class MatriarchalPowerStructureFramework(BaseLoreManager):
                 "Focus on character growth, relationships, and internal struggles, "
                 "while maintaining matriarchal power dynamics."
             ),
-            model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.9)
+            model="gpt-5-nano"
         )
         
         setting_agent = Agent(
@@ -591,8 +583,7 @@ class MatriarchalPowerStructureFramework(BaseLoreManager):
                 "Enrich the existing narrative with vivid locations, cultural details, "
                 "and environmental features that reinforce matriarchal themes."
             ),
-            model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.9)
+            model="gpt-5-nano"
         )
         
         # Dialogue-based development (alternating between agents)

--- a/lore/lore_agents.py
+++ b/lore/lore_agents.py
@@ -20,7 +20,7 @@ import time
 import functools
 
 # Agents SDK imports
-from agents import Agent, ModelSettings, function_tool, Runner, trace
+from agents import Agent, function_tool, Runner, trace
 from agents.models.openai_responses import OpenAIResponsesModel
 
 # Nyx governance integration
@@ -519,7 +519,6 @@ def create_lore_agent(
     name: str,
     instructions: str,
     output_type: Optional[Type] = None,
-    temperature: float = 0.5
 ) -> Agent:
     """
     Factory function to create lore agents with consistent settings.
@@ -528,7 +527,6 @@ def create_lore_agent(
         name: Agent name
         instructions: Agent instructions
         output_type: Expected output type
-        temperature: Model temperature
         
     Returns:
         Configured Agent instance
@@ -543,7 +541,6 @@ def create_lore_agent(
         name=name,
         instructions=base_instructions,
         model=OpenAIResponsesModel(model="gpt-5-nano"),
-        model_settings=ModelSettings(temperature=temperature),
         output_type=output_type,
     )
 
@@ -556,8 +553,7 @@ foundation_lore_agent = create_lore_agent(
         "[cosmology, magic_system, world_history, calendar_system, social_structure]. "
         "Do NOT include any extra text outside the JSON."
     ),
-    output_type=FoundationLoreOutput,
-    temperature=0.4
+    output_type=FoundationLoreOutput
 )
 
 factions_agent = create_lore_agent(
@@ -570,8 +566,7 @@ factions_agent = create_lore_agent(
         "Do NOT return just an array. Always wrap in an object with a 'factions' key. "
         "No extra text outside the JSON."
     ),
-    output_type=FactionsOutput,
-    temperature=0.7
+    output_type=FactionsOutput
 )
 
 cultural_agent = create_lore_agent(
@@ -583,8 +578,7 @@ cultural_agent = create_lore_agent(
         "historical_origin. Do NOT return just an array. Always wrap in an object with an 'elements' key. "
         "No extra text outside the JSON."
     ),
-    output_type=CulturalElementsOutput,
-    temperature=0.5
+    output_type=CulturalElementsOutput
 )
 
 history_agent = create_lore_agent(
@@ -596,8 +590,7 @@ history_agent = create_lore_agent(
         "consequences, significance. Do NOT return just an array. Always wrap in an object with an 'events' key. "
         "No extra text outside the JSON."
     ),
-    output_type=HistoricalEventsOutput,
-    temperature=0.6
+    output_type=HistoricalEventsOutput
 )
 
 locations_agent = create_lore_agent(
@@ -609,8 +602,7 @@ locations_agent = create_lore_agent(
         "hidden_secrets, strategic_importance. Do NOT return just an array. Always wrap in an object with a 'locations' key. "
         "No extra text outside the JSON."
     ),
-    output_type=LocationsOutput,
-    temperature=0.7
+    output_type=LocationsOutput
 )
 
 quests_agent = create_lore_agent(
@@ -623,8 +615,7 @@ quests_agent = create_lore_agent(
         "Do NOT return just an array. Always wrap in an object with a 'quests' key. "
         "No extra text outside the JSON."
     ),
-    output_type=QuestsOutput,
-    temperature=0.7
+    output_type=QuestsOutput
 )
 
 setting_analysis_agent = create_lore_agent(
@@ -636,8 +627,7 @@ setting_analysis_agent = create_lore_agent(
         "Each category is an array of objects with fields like name, type, "
         "description, membership_basis, hierarchy, gathering_location, etc. "
         "No extra text outside the JSON."
-    ),
-    temperature=0.7
+    )
 )
 
 integration_agent = create_lore_agent(
@@ -648,8 +638,7 @@ integration_agent = create_lore_agent(
         "inconsistencies, resolutions, and integrated data. "
         "No extra text outside the JSON."
     ),
-    output_type=IntegrationOutput,
-    temperature=0.5
+    output_type=IntegrationOutput
 )
 
 conflict_resolution_agent = create_lore_agent(
@@ -660,8 +649,7 @@ conflict_resolution_agent = create_lore_agent(
         "conflict description, resolution approach, and updated data. "
         "No extra text outside the JSON."
     ),
-    output_type=ConflictResolutionOutput,
-    temperature=0.6
+    output_type=ConflictResolutionOutput
 )
 
 validation_agent = create_lore_agent(
@@ -672,8 +660,7 @@ validation_agent = create_lore_agent(
         "is_valid (boolean), issues (array), and suggestions (array). "
         "No extra text outside the JSON."
     ),
-    output_type=ValidationOutput,
-    temperature=0.4
+    output_type=ValidationOutput
 )
 
 fix_agent = create_lore_agent(
@@ -684,8 +671,7 @@ fix_agent = create_lore_agent(
         "fix_description, updated_data, and affected_components. "
         "No extra text outside the JSON."
     ),
-    output_type=FixOutput,
-    temperature=0.5
+    output_type=FixOutput
 )
 
 relationship_validation_agent = create_lore_agent(
@@ -697,8 +683,7 @@ relationship_validation_agent = create_lore_agent(
         "relationship_suggestions (array). "
         "No extra text outside the JSON."
     ),
-    output_type=ValidationOutput, 
-    temperature=0.4
+    output_type=ValidationOutput
 )
 
 # -------------------------------------------------------------------------------

--- a/lore/lore_generator.py
+++ b/lore/lore_generator.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from db.connection import get_db_connection_context
 
 # Agents SDK imports
-from agents import Agent, ModelSettings, function_tool, Runner
+from agents import Agent, function_tool, Runner
 from agents.models.openai_responses import OpenAIResponsesModel
 from agents.run_context import RunContextWrapper
 
@@ -2093,7 +2093,6 @@ def get_foundation_lore_agent():
             model="gpt-5-nano", 
             openai_client=get_async_openai_client()
         ),
-        model_settings=ModelSettings(temperature=0.4),
         output_type=FoundationLoreOutput,
     )
 
@@ -2135,7 +2134,6 @@ def get_factions_agent():
             model="gpt-5-nano", 
             openai_client=get_async_openai_client()
         ),
-        model_settings=ModelSettings(temperature=0.7),
         output_type=FactionsOutput,
     )
 
@@ -2156,7 +2154,6 @@ def get_cultural_agent():
             model="gpt-5-nano", 
             openai_client=get_async_openai_client()
         ),
-        model_settings=ModelSettings(temperature=0.5),
         output_type=CulturalElementsOutput,
     )
 
@@ -2177,7 +2174,6 @@ def get_history_agent():
             model="gpt-5-nano", 
             openai_client=get_async_openai_client()
         ),
-        model_settings=ModelSettings(temperature=0.6),
         output_type=HistoricalEventsOutput,
     )
 
@@ -2200,7 +2196,6 @@ def get_locations_agent():
             model="gpt-5-nano", 
             openai_client=get_async_openai_client()
         ),
-        model_settings=ModelSettings(temperature=0.7),
         output_type=LocationsOutput,
     )
 
@@ -2222,6 +2217,5 @@ def get_quests_agent():
             model="gpt-5-nano", 
             openai_client=get_async_openai_client()
         ),
-        model_settings=ModelSettings(temperature=0.7),
         output_type=QuestsOutput,
     )

--- a/lore/lore_orchestrator.py
+++ b/lore/lore_orchestrator.py
@@ -36,7 +36,7 @@ from nyx.nyx_governance import AgentType, DirectiveType, DirectivePriority
 from nyx.governance_helpers import with_governance, with_governance_permission
 
 # Agents SDK imports for new managers
-from agents import Agent, function_tool, Runner, ModelSettings, trace, handoff
+from agents import Agent, function_tool, Runner, trace, handoff
 from agents.run import RunConfig
 from agents.run_context import RunContextWrapper
 from pydantic import BaseModel, Field

--- a/lore/managers/base_manager.py
+++ b/lore/managers/base_manager.py
@@ -10,12 +10,11 @@ from typing import Dict, List, Any, Optional, Type, Set, Callable, Protocol, run
 
 # Agents SDK imports - v0.0.17 best practices
 from agents import (
-    Agent, 
-    Runner, 
-    function_tool, 
-    trace, 
-    RunContextWrapper, 
-    ModelSettings,
+    Agent,
+    Runner,
+    function_tool,
+    trace,
+    RunContextWrapper,
     GuardrailFunctionOutput
 )
 from agents.run import RunConfig

--- a/lore/managers/education.py
+++ b/lore/managers/education.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field
 from agents import (
     Agent, function_tool, Runner, trace,
     GuardrailFunctionOutput, InputGuardrail, handoff,
-    RunContextWrapper, RunConfig, ModelSettings
+    RunContextWrapper, RunConfig
 )
 
 # Governance & others

--- a/lore/managers/geopolitical.py
+++ b/lore/managers/geopolitical.py
@@ -14,8 +14,8 @@ from db.connection import get_db_connection_context
 logger = logging.getLogger(__name__)
 # OpenAI Agents SDK imports
 from agents import (
-    Agent, function_tool, Runner, trace, RunConfig, ModelSettings, RunResultStreaming,
-    GuardrailFunctionOutput, InputGuardrail, handoff, ModelSettings
+    Agent, function_tool, Runner, trace, RunConfig, RunResultStreaming,
+    GuardrailFunctionOutput, InputGuardrail, handoff
 )
 from agents.run_context import RunContextWrapper
 from agents.run import RunConfig

--- a/lore/managers/local_lore.py
+++ b/lore/managers/local_lore.py
@@ -30,7 +30,7 @@ from datetime import datetime
 
 # Agents SDK imports
 from agents import (
-    Agent, function_tool, Runner, trace, RunResultStreaming, ModelSettings,
+    Agent, function_tool, Runner, trace, RunResultStreaming,
     GuardrailFunctionOutput, InputGuardrail, OutputGuardrail, handoff, RunContextWrapper, RunConfig
 )
 

--- a/lore/managers/politics.py
+++ b/lore/managers/politics.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Any, Optional, AsyncGenerator
 from datetime import datetime
 
 # Agents SDK imports
-from agents import Agent, function_tool, Runner, ModelSettings, RunContextWrapper, RunConfig, trace
+from agents import Agent, function_tool, Runner, RunContextWrapper, RunConfig, trace
 
 from pydantic import BaseModel, Field
 

--- a/lore/managers/religion.py
+++ b/lore/managers/religion.py
@@ -9,10 +9,9 @@ from enum import Enum
 
 # Agents SDK imports
 from agents import (
-    Agent, 
-    function_tool, 
-    Runner, 
-    ModelSettings,
+    Agent,
+    function_tool,
+    Runner,
     RunConfig,
     handoff,
     InputGuardrail,

--- a/lore/managers/world_lore_manager.py
+++ b/lore/managers/world_lore_manager.py
@@ -19,7 +19,7 @@ import random
 import re
 
 # Agents SDK (import what you need)
-from agents import Agent, function_tool, Runner, trace, ModelSettings, handoff
+from agents import Agent, function_tool, Runner, trace, handoff
 from agents.run import RunConfig
 from agents.run_context import RunContextWrapper
 

--- a/lore/matriarchal_lore_system.py
+++ b/lore/matriarchal_lore_system.py
@@ -9,7 +9,7 @@ import datetime
 from typing import Dict, List, Any, Optional, Set, Tuple
 
 # Agents SDK imports
-from agents import Agent, ModelSettings, function_tool, Runner
+from agents import Agent, function_tool, Runner
 from agents.run_context import RunContextWrapper
 
 # Nyx governance integration
@@ -3209,7 +3209,6 @@ class LoreUpdateSystem:
                 Consider how changes cascade through relationship networks.
                 """,
                 model=model_name,
-                temperature=0.7
             )
             
             # Get the response with enhanced error handling

--- a/lore/systems/dynamics.py
+++ b/lore/systems/dynamics.py
@@ -17,7 +17,6 @@ import lore.core.canon as canon
 # ------------------ AGENTS SDK IMPORTS ------------------
 from agents import (
     Agent,
-    ModelSettings,
     Runner,
     function_tool,
     handoff,
@@ -337,8 +336,6 @@ class LoreDynamicsSystem(BaseLoreManager):
             "Male elements should be presented in supportive or subservient positions."
         )
         
-        model_settings = ModelSettings(temperature=0.9)
-        
         agent_configs = {
             "lore_update": {
                 "name": "LoreUpdateAgent",
@@ -362,7 +359,6 @@ class LoreDynamicsSystem(BaseLoreManager):
                     "Never use types like 'character_trait', 'Legal Reform', etc."
                 ),
                 "model": "gpt-5-nano",
-                "settings": model_settings
             },
             "event_generation": {
                 "name": "EventGenerationAgent",
@@ -373,7 +369,6 @@ class LoreDynamicsSystem(BaseLoreManager):
                     "and plot advancement. Focus on how events impact or reinforce matriarchal power dynamics."
                 ),
                 "model": "gpt-5-nano",
-                "settings": model_settings
             },
             "lore_creation": {
                 "name": "LoreCreationAgent",
@@ -384,7 +379,6 @@ class LoreDynamicsSystem(BaseLoreManager):
                     "Ensure all new lore reinforces matriarchal power dynamics."
                 ),
                 "model": "gpt-5-nano",
-                "settings": model_settings
             },
             "political_event": {
                 "name": "PoliticalEventAgent",
@@ -395,7 +389,6 @@ class LoreDynamicsSystem(BaseLoreManager):
                     "Events should highlight feminine leadership and authority."
                 ),
                 "model": "gpt-5-nano",
-                "settings": model_settings
             },
             "military_event": {
                 "name": "MilitaryEventAgent",
@@ -406,7 +399,6 @@ class LoreDynamicsSystem(BaseLoreManager):
                     "Events should highlight feminine military command structures."
                 ),
                 "model": "gpt-5-nano",
-                "settings": model_settings
             },
             "cultural_event": {
                 "name": "CulturalEventAgent",
@@ -417,17 +409,15 @@ class LoreDynamicsSystem(BaseLoreManager):
                     "Events should highlight feminine cultural influence and values."
                 ),
                 "model": "gpt-5-nano",
-                "settings": model_settings
             }
         }
-        
+
         # Create agents
         for key, config in agent_configs.items():
             self._agents[key] = Agent(
                 name=config["name"],
                 instructions=config["instructions"],
                 model=config["model"],
-                model_settings=config["settings"]
             )
     
     async def ensure_initialized(self):
@@ -491,7 +481,6 @@ class LoreDynamicsSystem(BaseLoreManager):
                 "narrative elements that can drive lore evolution."
             ),
             model="gpt-5-nano",
-            model_settings=ModelSettings(),
             output_type=EventValidation
         )
         
@@ -1050,7 +1039,6 @@ class LoreDynamicsSystem(BaseLoreManager):
                 "Output valid JSON with these keys."
             ),
             model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.9),
             output_type=SocietalImpact
         )
         
@@ -1404,7 +1392,6 @@ class LoreDynamicsSystem(BaseLoreManager):
                 "Return JSON with a single field: {'event_type': 'the chosen type'}"
             ),
             model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.8),
             output_type=EventType
         )
         
@@ -1504,7 +1491,6 @@ class LoreDynamicsSystem(BaseLoreManager):
                 "Otherwise, hand off to 'transfer_to_cultural_agent'."
             ),
             model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.8),
             handoffs=[
                 handoff(
                     self._get_agent("political_event"),
@@ -2128,7 +2114,6 @@ class LoreDynamicsSystem(BaseLoreManager):
                     "Return only the new, updated description in a cohesive style."
                 ),
                 model="gpt-5-nano",
-                model_settings=ModelSettings(temperature=0.8)
             )
             
             # Potential change types
@@ -2284,7 +2269,6 @@ class LoreDynamicsSystem(BaseLoreManager):
                     "territory, or governance. Keep the matriarchal theme strong."
                 ),
                 model="gpt-5-nano",
-                model_settings=ModelSettings(temperature=0.8)
             )
             
             # Do 1 or 2 shifts randomly
@@ -2535,7 +2519,6 @@ class LoreDynamicsSystem(BaseLoreManager):
                     "Given a change_type, rewrite their description to reflect that new condition."
                 ),
                 model="gpt-5-nano",
-                model_settings=ModelSettings(temperature=0.8)
             )
             
             # Potential changes
@@ -2712,7 +2695,6 @@ class MultiStepPlanner:
             Maintain matriarchal themes throughout the planning process.
             """,
             model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.8),
             output_type=NarrativePlan
         )
     
@@ -3122,7 +3104,6 @@ class NarrativeEvaluator:
             Consider themes, character motivations, plot development, and matriarchal elements.
             """,
             model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.7),
             output_type=NarrativeEvaluation
         )
         self.feedback_history = []
@@ -3328,7 +3309,6 @@ class NarrativeEvolutionSystem:
             Select elements that enhance the overall narrative, maintain consistency, and advance matriarchal themes.
             """,
             model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.7),
             output_type=EventSelection
         )
         self.mutation_agent = Agent(
@@ -3338,7 +3318,6 @@ class NarrativeEvolutionSystem:
             Enhance matriarchal themes and ensure coherent integration with the world.
             """,
             model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.9),
             output_type=MutationDirectives
         )
     
@@ -3589,7 +3568,6 @@ class WorldStateStreamer:
             and emerging patterns. Focus on matriarchal power dynamics.
             """,
             model="gpt-5-nano",
-            model_settings=ModelSettings(temperature=0.8)
         )
     
     async def stream_world_changes(self, event_data: Dict[str, Any], affected_elements: List[Dict[str, Any]]) -> AsyncGenerator[Dict[str, Any], None]:

--- a/lore/systems/regional_culture.py
+++ b/lore/systems/regional_culture.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel, Field
 # ------------------ AGENTS SDK IMPORTS ------------------
 from agents import (
     Agent,
-    ModelSettings,
     Runner,
     function_tool,
     trace,
@@ -188,8 +187,6 @@ class RegionalCultureSystem(BaseLoreManager):
             "Male elements are typically supportive or subordinate. Provide detail and realism."
         )
         
-        model_settings = ModelSettings(temperature=0.9)
-        
         agent_configs = {
             "language": {
                 "name": "LanguageGenerationAgent",
@@ -199,7 +196,6 @@ class RegionalCultureSystem(BaseLoreManager):
                     "Reflect how language encodes status, formality, and gender hierarchy."
                 ),
                 "model": "gpt-5-nano",
-                "settings": model_settings
             },
             "norm": {
                 "name": "CulturalNormAgent",
@@ -209,7 +205,6 @@ class RegionalCultureSystem(BaseLoreManager):
                     "Consider differences by gender, status, and context. Provide taboos, consequences, variations."
                 ),
                 "model": "gpt-5-nano",
-                "settings": model_settings
             },
             "etiquette": {
                 "name": "EtiquetteAgent",
@@ -220,7 +215,6 @@ class RegionalCultureSystem(BaseLoreManager):
                     "Be explicit about how men must defer to female authority."
                 ),
                 "model": "gpt-5-nano",
-                "settings": model_settings
             },
             "distribution": {
                 "name": "LanguageDistributionAgent",
@@ -231,7 +225,6 @@ class RegionalCultureSystem(BaseLoreManager):
                     "Some languages might be major (used by multiple large nations), others minor."
                 ),
                 "model": "gpt-5-nano",
-                "settings": ModelSettings(temperature=0.8)
             },
             "category": {
                 "name": "NormCategoryAgent",
@@ -241,7 +234,6 @@ class RegionalCultureSystem(BaseLoreManager):
                     "and how many norms total. Consider the nation's specific characteristics."
                 ),
                 "model": "gpt-5-nano",
-                "settings": ModelSettings(temperature=0.8)
             },
             "context": {
                 "name": "EtiquetteContextAgent",
@@ -251,7 +243,6 @@ class RegionalCultureSystem(BaseLoreManager):
                     "Consider the nation's government type and cultural traits."
                 ),
                 "model": "gpt-5-nano",
-                "settings": ModelSettings(temperature=0.8)
             },
             "summary": {
                 "name": "CultureSummaryAgent",
@@ -261,7 +252,6 @@ class RegionalCultureSystem(BaseLoreManager):
                     "and any notable linguistic or etiquette features."
                 ),
                 "model": "gpt-5-nano",
-                "settings": ModelSettings(temperature=0.8)
             },
             "conflict": {
                 "name": "CulturalConflictAnalyst",
@@ -271,7 +261,6 @@ class RegionalCultureSystem(BaseLoreManager):
                     "Provide specific conflicts, severity assessment, and diplomatic recommendations."
                 ),
                 "model": "gpt-5-nano",
-                "settings": ModelSettings(temperature=0.8)
             },
             "diffusion": {
                 "name": "CulturalDiffusionAgent",
@@ -282,7 +271,6 @@ class RegionalCultureSystem(BaseLoreManager):
                     "Maintain matriarchal power structures as the dominant framework."
                 ),
                 "model": "gpt-5-nano",
-                "settings": model_settings
             },
             "dialect": {
                 "name": "DialectEvolutionAgent",
@@ -293,7 +281,6 @@ class RegionalCultureSystem(BaseLoreManager):
                     "matriarchal power structures and feminine-dominated society."
                 ),
                 "model": "gpt-5-nano",
-                "settings": model_settings
             }
         }
         
@@ -303,7 +290,6 @@ class RegionalCultureSystem(BaseLoreManager):
                 name=config["name"],
                 instructions=config["instructions"],
                 model=config["model"],
-                model_settings=config["settings"]
             )
     
     async def ensure_initialized(self):


### PR DESCRIPTION
## Summary
- remove explicit ModelSettings temperature overrides from gpt-5-nano lore agents and systems so they fall back to default OpenAI settings
- clean up unused imports and stray temperature parameters left after the override removal

## Testing
- python -m compileall lore

Additional Notes:
- Unable to exercise the background lore Celery flow in this environment because no OpenAI API credentials are available.

------
https://chatgpt.com/codex/tasks/task_e_68d5b19e61288321b5670a45a8098237