### PR TITLE
Ensure NPC lore initialization has contextual npc_id

### DIFF
--- a/lore/lore_routes.py
+++ b/lore/lore_routes.py
@@ -10,6 +10,8 @@ import logging
 from quart import Blueprint, request, jsonify, session
 from typing import Dict, Any
 
+from agents import RunContextWrapper
+
 # Import core lore system
 from lore.core.lore_system import LoreSystem
 
@@ -190,10 +192,19 @@ async def integrate_lore_with_npcs_route(user_id):
             # Get NPC details (name, background, etc.)
             # This would use your NPC data access layer
             npc_details = {"cultural_background": "default", "faction_affiliations": []}
-            
+
             # Initialize NPC knowledge
+            npc_context = RunContextWrapper(context={
+                "user_id": user_id,
+                "conversation_id": conversation_id,
+                "npc_id": npc_id,
+            })
+            npc_context.user_id = user_id
+            npc_context.conversation_id = conversation_id
+            npc_context.npc_id = npc_id
+
             result = await lore_system.initialize_npc_lore_knowledge(
-                None,
+                npc_context,
                 npc_id,
                 npc_details.get("cultural_background", "unknown"),
                 npc_details.get("faction_affiliations", [])

--- a/tasks.py
+++ b/tasks.py
@@ -920,14 +920,17 @@ def generate_lore_background_task(user_id: int, conversation_id: int) -> Dict[st
             from lore.core.lore_system import LoreSystem
 
             lore_system = await LoreSystem.get_instance(user_id, conversation_id)
-            lore_ctx = RunContextWrapper(context={
+            base_context = {
                 "user_id": user_id,
                 "conversation_id": conversation_id,
-            })
+            }
+            lore_ctx = RunContextWrapper(context=base_context)
             lore_ctx.user_id = user_id
             lore_ctx.conversation_id = conversation_id
 
-            lore_result = await lore_system.generate_complete_lore(lore_ctx, environment_desc)
+            lore_result = await lore_system.generate_complete_lore(
+                lore_ctx, environment_desc
+            )
 
             if npc_ids:
                 logger.info(
@@ -958,8 +961,15 @@ def generate_lore_background_task(user_id: int, conversation_id: int) -> Dict[st
                             if isinstance(affiliations_data, list):
                                 faction_affiliations = affiliations_data
 
+                    npc_context = dict(base_context)
+                    npc_context["npc_id"] = npc_id
+                    npc_ctx = RunContextWrapper(context=npc_context)
+                    npc_ctx.user_id = user_id
+                    npc_ctx.conversation_id = conversation_id
+                    npc_ctx.npc_id = npc_id
+
                     await lore_system.initialize_npc_lore_knowledge(
-                        lore_ctx,
+                        npc_ctx,
                         npc_id,
                         cultural_background="common",
                         faction_affiliations=faction_affiliations,


### PR DESCRIPTION
## Summary
- create a base lore RunContextWrapper for conversation state and clone it per NPC so each initialization call has its own npc_id
- update the lore integration route to build a RunContextWrapper carrying user, conversation, and npc identifiers before invoking initialization

## Testing
- pytest -k lore --maxfail=1 -o addopts= *(fails: ModuleNotFoundError: No module named 'memory')*

------
https://chatgpt.com/codex/tasks/task_e_68d5b878cdd48321bded54a85bbba5f5