### PR TITLE
Support temperature overrides for GPT service

### DIFF
--- a/npcs/new_npc_creation.py
+++ b/npcs/new_npc_creation.py
@@ -29,7 +29,12 @@ from memory.semantic import SemanticMemoryManager
 from memory.masks import ProgressiveRevealManager, RevealType, RevealSeverity
 from memory.reconsolidation import ReconsolidationManager
 
-from logic.chatgpt_integration import get_openai_client, get_chatgpt_response, get_async_openai_client
+from logic.chatgpt_integration import (
+    get_openai_client,
+    get_chatgpt_response,
+    get_async_openai_client,
+    ALLOWS_TEMPERATURE,
+)
 from logic.gpt_utils import spaced_gpt_call
 from logic.gpt_helpers import fetch_npc_name
 from logic.calendar import load_calendar_names
@@ -80,6 +85,7 @@ async def _responses_json_call(
     user_prompt: str,
     max_output_tokens: int | None = None,
     previous_response_id: str | None = None,
+    temperature: float | None = None,
 ) -> str:
     """
     Wrapper around `client.responses.create()`.
@@ -97,6 +103,9 @@ async def _responses_json_call(
     }
     if previous_response_id:
         params["previous_response_id"] = previous_response_id
+
+    if temperature is not None and model in ALLOWS_TEMPERATURE:
+        params["temperature"] = temperature
 
     # --- call the endpoint ----------------------------------------------
     try:


### PR DESCRIPTION
## Summary
- allow GPTService callers to override temperature (and other GPT call kwargs)
- include call options in the GPT cache key and forward them down to the NPC responses helper
- update NPC responses helper to pass temperature to the OpenAI Responses API when supported

## Testing
- `PYTHONPATH=. pytest --override-ini=addopts= tests/unit/test_npc_system.py::test_npc_creation` *(fails: requires downloading Hugging Face model, blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5d2e4d01c8321b904320538127709