### PR TITLE
Fix JSONB serialization for lore tags

### DIFF
--- a/lore/lore_generator.py
+++ b/lore/lore_generator.py
@@ -866,11 +866,11 @@ class WorldBuilder(BaseGenerator):
                 INSERT INTO WorldLore (
                     user_id, conversation_id, name, category,
                     description, significance, tags, created_at
-                ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, NOW())
                 RETURNING id
             """
 
-            # tags should be passed as a list directly for TEXT[] column
+            # tags column is JSONB, serialize the Python list before sending to Postgres
             async with get_db_connection_context() as conn:
                 lore_id = await conn.fetchval(
                     query,
@@ -880,7 +880,7 @@ class WorldBuilder(BaseGenerator):
                     category,
                     description,
                     significance,
-                    tags,  # Pass as list, not JSON string
+                    json.dumps(tags),
                 )
 
                 return lore_id

--- a/tests/test_lore_generator_schema.py
+++ b/tests/test_lore_generator_schema.py
@@ -1,11 +1,15 @@
 from pathlib import Path
 import sys
+import json
+import asyncio
 
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from lore.lore_generator import BaseGenerator
+from contextlib import asynccontextmanager
+
+from lore.lore_generator import BaseGenerator, WorldBuilder
 
 
 class DummyConn:
@@ -60,3 +64,55 @@ async def test_resolve_faction_pk_caches_value():
     cached_column = await generator._resolve_faction_pk_column(DummyConnNoAccess())
 
     assert cached_column == "faction_id"
+
+
+class RecordingConn:
+    def __init__(self, response=42):
+        self.response = response
+        self.calls = 0
+        self.query = None
+        self.args = None
+
+    async def fetchval(self, query, *args):
+        self.calls += 1
+        self.query = query
+        self.args = args
+        return self.response
+
+
+def test_store_world_lore_serializes_tags(monkeypatch):
+    builder = WorldBuilder(user_id=99, conversation_id=123)
+    conn = RecordingConn(response=7)
+
+    @asynccontextmanager
+    async def fake_connection_context(*args, **kwargs):
+        yield conn
+
+    monkeypatch.setattr(
+        "lore.lore_generator.get_db_connection_context",
+        fake_connection_context,
+    )
+
+    async def run_store():
+        return await builder._store_world_lore(
+            name="Test Lore",
+            category="myth",
+            description="A legend",
+            significance=5,
+            tags=["legend", "ancient"],
+        )
+
+    lore_id = asyncio.run(run_store())
+
+    assert lore_id == 7
+    assert conn.calls == 1
+    assert conn.query is not None and "::jsonb" in conn.query
+    assert conn.args[6] == json.dumps(["legend", "ancient"])
+    assert conn.args[:6] == (
+        99,
+        123,
+        "Test Lore",
+        "myth",
+        "A legend",
+        5,
+    )


### PR DESCRIPTION
## Summary
- serialize world lore tag lists before insertion so JSONB columns receive valid payloads
- update the lore generator comment to reference the JSONB storage
- add a unit test exercising `_store_world_lore` to confirm list tags are serialized and inserted

## Testing
- pytest --override-ini=addopts= tests/test_lore_generator_schema.py -k serializes


------
https://chatgpt.com/codex/tasks/task_e_68d6ca29e1388321842d419e971a1be7