### PR TITLE
Expose template conflict identifiers for initial conflict naming

### DIFF
--- a/tests/test_initial_conflict_generation.py
+++ b/tests/test_initial_conflict_generation.py
@@ -367,3 +367,85 @@ def test_generate_initial_conflict_uses_db_name_when_conflict_names_missing(
     assert args[-1] == "Stored Conflict Name"
 
     assert not connections
+
+
+def test_generate_initial_conflict_resolves_template_subsystem_conflict_id(
+    tasks_module, monkeypatch
+):
+    monkeypatch.setattr(tasks_module, "RunContextWrapper", DummyRunContext)
+
+    def _run(coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    monkeypatch.setattr(tasks_module, "run_async_in_worker_loop", _run)
+
+    template_response = {
+        "success": True,
+        "raw_result": {
+            "status": "created",
+            "conflict_type": "major",
+            "conflict_id": 555,
+            "subsystem_responses": {
+                "template": {
+                    "template_used": 42,
+                    "generated_conflict": 555,
+                    "conflict_id": 555,
+                    "narrative_hooks": ["Hook one", "Hook two"],
+                }
+            },
+        },
+        "conflict_details": {},
+        "conflict_id": 555,
+    }
+
+    class _TemplateConflictIntegration:
+        def __init__(self, response):
+            self._response = response
+
+        async def initialize(self):
+            return None
+
+        async def generate_conflict(self, *args, **kwargs):
+            return self._response
+
+        @classmethod
+        async def get_instance(cls, *args, **kwargs):
+            return cls(template_response)
+
+    monkeypatch.setattr(
+        sys.modules["logic.conflict_system.conflict_integration"],
+        "ConflictSystemIntegration",
+        _TemplateConflictIntegration,
+    )
+
+    first_conn = DummyConnection()
+    second_conn = DummyConnection(fetchval_result=3)
+    third_conn = DummyConnection(fetchval_result="Template Stored Name")
+    fourth_conn = DummyConnection()
+    connections = [first_conn, second_conn, third_conn, fourth_conn]
+
+    def fake_get_db_connection_context():
+        if not connections:
+            raise AssertionError("No more connections available")
+        return DummyContextManager(connections.pop(0))
+
+    monkeypatch.setattr(
+        tasks_module, "get_db_connection_context", fake_get_db_connection_context
+    )
+
+    result = tasks_module.generate_initial_conflict_task(user_id=5, conversation_id=99)
+
+    assert result["initial_conflict"] == "Template Stored Name"
+
+    summary_calls = [
+        call for call in fourth_conn.execute_calls if "InitialConflictSummary" in call[0]
+    ]
+    assert summary_calls, "Expected InitialConflictSummary write"
+    _, args = summary_calls[0]
+    assert args[-1] == "Template Stored Name"
+
+    assert not connections


### PR DESCRIPTION
## Summary
- ensure the dynamic conflict template subsystem returns conflict identifiers and human-readable names when generating conflicts
- fall back to direct conflict insertion when the synthesizer response omits a conflict identifier
- add coverage ensuring the initial conflict Celery task resolves database names when template responses lack titles

## Testing
- pytest tests/test_initial_conflict_generation.py

------
https://chatgpt.com/codex/tasks/task_e_68dadc0174a083219395bab89358fb72