### PR TITLE
Handle AI image timeouts in new game setup

### DIFF
--- a/new_game_agent.py
+++ b/new_game_agent.py
@@ -3163,10 +3163,18 @@ class NewGameAgent:
                 # Parse back to dict for the function call
                 scene_data = json.loads(scene_data_json)
                 
-                image_result = await generate_roleplay_image_from_gpt(scene_data, user_id, conversation_id)
-                if image_result and "image_urls" in image_result and image_result["image_urls"]:
+                image_result = await generate_roleplay_image_from_gpt(
+                    scene_data,
+                    user_id,
+                    conversation_id,
+                    timeout=5.0,
+                )
+
+                if image_result is None:
+                    logging.info("Welcome image generation skipped due to timeout or upstream failure")
+                elif "image_urls" in image_result and image_result["image_urls"]:
                     welcome_image_url = image_result["image_urls"][0]
-                    
+
                     # Store the image URL canonically
                     async with get_db_connection_context() as conn:
                         await canon.update_current_roleplay(


### PR DESCRIPTION
## Summary
- add a configurable timeout to the SinkIn image generation client and run it in a background thread to avoid blocking async flows
- teach the new game setup to treat a timed out image request as a soft failure and continue without a welcome image
- add a regression test that simulates a slow image backend and confirms the new game task still marks the conversation ready

## Testing
- PYTEST_ADDOPTS="--no-cov" pytest tests/test_new_game_agent_background.py -k timeout

------
https://chatgpt.com/codex/tasks/task_e_68db8c023084832181b4e4d05a4c9025