### PR TITLE
Handle canonical memory persistence during shutdown

### DIFF
--- a/tests/test_canon_memory.py
+++ b/tests/test_canon_memory.py
@@ -1,13 +1,36 @@
 import asyncio
 import os
 import sys
+from datetime import datetime
 from types import SimpleNamespace
+import types
 
 import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
+os.environ.setdefault("HF_HUB_OFFLINE", "1")
+os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+os.environ.setdefault("SENTENCE_TRANSFORMERS_OFFLINE", "1")
+os.environ.setdefault("SENTENCE_TRANSFORMERS_HOME", os.path.join(os.getcwd(), ".st_cache"))
+os.makedirs(os.environ["SENTENCE_TRANSFORMERS_HOME"], exist_ok=True)
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+if "nyx.core.memory.vector_store" not in sys.modules:
+    vector_store_stub = types.ModuleType("nyx.core.memory.vector_store")
+
+    async def _stub_add(text, meta):
+        return "stub"
+
+    async def _stub_query(ctx, k: int = 5):
+        return []
+
+    vector_store_stub.add = _stub_add  # type: ignore[attr-defined]
+    vector_store_stub.query = _stub_query  # type: ignore[attr-defined]
+    sys.modules["nyx.core.memory.vector_store"] = vector_store_stub
+
 from lore.core.canon import log_canonical_event
+from lore.core import canon as canon_module
 
 
 class DummyConnection:
@@ -98,6 +121,7 @@ async def test_log_canonical_event_memory_errors_logged(monkeypatch, caplog):
         "lore.core.canon.get_canon_memory_orchestrator",
         fake_get_canon_memory_orchestrator,
     )
+    monkeypatch.setattr(canon_module, "_TRACK_OPERATION_AVAILABLE", False)
 
     with caplog.at_level("ERROR"):
         event_id = await log_canonical_event(
@@ -114,5 +138,79 @@ async def test_log_canonical_event_memory_errors_logged(monkeypatch, caplog):
     assert event_id == 1
     assert any(
         "Failed to persist canonical event" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_schedule_canonical_memory_persist_skips_when_shutting_down(monkeypatch):
+    ctx = SimpleNamespace(user_id=1, conversation_id=2)
+
+    async def fail_persist(*args, **kwargs):  # pragma: no cover - defensive
+        raise AssertionError("Persistence coroutine should not run while shutting down")
+
+    def fail_create_task(coro):  # pragma: no cover - defensive
+        raise AssertionError("create_task should not be invoked during shutdown")
+
+    monkeypatch.setattr(canon_module, "is_shutting_down", lambda: True)
+    monkeypatch.setattr(canon_module, "_persist_canonical_event_memory", fail_persist)
+    monkeypatch.setattr(asyncio, "create_task", fail_create_task)
+
+    canon_module._schedule_canonical_memory_persist(
+        ctx,
+        event_id=123,
+        event_text="shutdown test",
+        tags=["test"],
+        significance=1,
+        parent_ids=[],
+        event_timestamp=datetime.utcnow(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_schedule_canonical_memory_persist_handles_track_operation_shutdown(
+    monkeypatch, caplog
+):
+    ctx = SimpleNamespace(user_id=3, conversation_id=4)
+    created_tasks = []
+
+    async def noop_persist(*args, **kwargs):
+        return None
+
+    async def failing_track_operation(coro):
+        raise ConnectionError("worker shutting down")
+
+    original_create_task = asyncio.create_task
+
+    def tracking_create_task(coro):
+        task = original_create_task(coro)
+        created_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(canon_module, "is_shutting_down", lambda: False)
+    monkeypatch.setattr(canon_module, "_persist_canonical_event_memory", noop_persist)
+    monkeypatch.setattr(canon_module, "track_operation", failing_track_operation)
+    monkeypatch.setattr(canon_module, "_TRACK_OPERATION_AVAILABLE", True)
+    monkeypatch.setattr(asyncio, "create_task", tracking_create_task)
+
+    with caplog.at_level("INFO"):
+        canon_module._schedule_canonical_memory_persist(
+            ctx,
+            event_id=456,
+            event_text="track op shutdown",
+            tags=["test"],
+            significance=2,
+            parent_ids=[],
+            event_timestamp=datetime.utcnow(),
+        )
+
+        # Allow the scheduled task to run and handle the ConnectionError.
+        await asyncio.sleep(0)
+
+    assert created_tasks, "Expected the shutdown-safe wrapper task to be scheduled"
+    await asyncio.gather(*created_tasks)
+
+    assert any(
+        "Skipping canonical memory persistence due to shutdown" in record.getMessage()
         for record in caplog.records
     )

--- a/tests/test_db_connection_shutdown.py
+++ b/tests/test_db_connection_shutdown.py
@@ -1,0 +1,34 @@
+import asyncio
+
+import pytest
+
+from db import connection as db_connection
+
+
+@pytest.mark.asyncio
+async def test_track_operation_respects_shutdown(monkeypatch):
+    """Ensure Celery shutdown path rejects new operations cleanly."""
+
+    # Start from a clean slate for shutdown tracking.
+    monkeypatch.setattr(db_connection, "_SHUTTING_DOWN", False)
+    monkeypatch.setattr(db_connection, "_SHUTTING_DOWN_PIDS", set())
+    monkeypatch.setattr(db_connection, "_pending_operations", set())
+    monkeypatch.setattr(db_connection, "_pending_operations_lock", None)
+
+    async def sample_operation():
+        await asyncio.sleep(0)
+        return "ok"
+
+    # Normal operation should succeed.
+    result = await db_connection.track_operation(sample_operation())
+    assert result == "ok"
+
+    # Simulate Celery shutdown and ensure new work is rejected.
+    db_connection.mark_shutting_down()
+    assert db_connection.is_shutting_down() is True
+
+    with pytest.raises(ConnectionError):
+        await db_connection.track_operation(sample_operation())
+
+    # No pending work should remain and shutdown wait should be a no-op.
+    await db_connection.wait_for_pending_operations()


### PR DESCRIPTION
## Summary
- guard canonical memory persistence scheduling against worker teardown by checking `is_shutting_down`, wrapping tasks with `track_operation`, and re-logging connection shutdowns when necessary
- stabilize canon tests by stubbing heavy dependencies, exercising shutdown skip behavior, and confirming connection-error handling stays quiet
- add a regression test around the Celery shutdown helpers to ensure `track_operation` rejects work once shutdown is marked

## Testing
- pytest tests/test_canon_memory.py tests/test_db_connection_shutdown.py

------
https://chatgpt.com/codex/tasks/task_e_68dda18a7f1c832186f757310d84bec1