### PR TITLE
Align opening context with schedule-driven locations

### DIFF
--- a/tests/test_new_game_agent_background.py
+++ b/tests/test_new_game_agent_background.py
@@ -1,10 +1,12 @@
 import asyncio
 import contextlib
+import json
 import os
 import pathlib
 import sys
 import types
 from contextlib import asynccontextmanager
+from datetime import datetime
 
 import pytest
 
@@ -587,4 +589,86 @@ def test_process_new_game_task_handles_image_timeout(monkeypatch):
     assert result["welcome_image_url"] is None
     assert timeouts_seen == [5.0]
     assert any("status='ready'" in query for query, _ in status_updates)
+
+
+def test_initialize_player_context_aligns_with_schedule(monkeypatch):
+    user_id = 99
+    conversation_id = 123
+
+    fixed_now = datetime(2024, 3, 18, 9, 30)
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return fixed_now
+            return fixed_now.replace(tzinfo=tz)
+
+    monkeypatch.setattr(new_game_agent, "datetime", FixedDateTime)
+
+    schedule = {
+        "Monday": {
+            "Morning": "Chase prepares for the day at Town Square",
+            "Afternoon": "Chase attends to responsibilities at Observation Park",
+            "Evening": "Chase spends time on personal activities at Observation Park",
+            "Night": "Chase returns home and rests",
+        }
+    }
+
+    location_rows = [
+        {"location_name": "Town Square"},
+        {"location_name": "Observation Park"},
+    ]
+
+    class DummyConnection:
+        async def fetch(self, query, *args):
+            if "FROM Locations" in query:
+                return location_rows
+            return []
+
+        async def fetchrow(self, query, *args):
+            if "ChaseSchedule" in query:
+                return {"value": json.dumps(schedule)}
+            return None
+
+        async def execute(self, query, *args):
+            return None
+
+    @asynccontextmanager
+    async def fake_db_context():
+        yield DummyConnection()
+
+    monkeypatch.setattr(new_game_agent, "get_db_connection_context", fake_db_context)
+
+    async def fake_load_calendar_names(unused_user_id, unused_conversation_id):
+        return {"months": ["Month"], "days": ["Monday"], "seasons": []}
+
+    monkeypatch.setattr(new_game_agent, "load_calendar_names", fake_load_calendar_names)
+
+    recorded_time_args = {}
+
+    async def fake_set_current_time(*args):
+        recorded_time_args["args"] = args
+
+    monkeypatch.setattr(new_game_agent, "set_current_time", fake_set_current_time)
+
+    updates = []
+
+    async def fake_update_current_roleplay(ctx, conn, key, value):
+        updates.append((key, value))
+
+    monkeypatch.setattr(new_game_agent.canon, "update_current_roleplay", fake_update_current_roleplay)
+
+    async def runner():
+        agent = new_game_agent.NewGameAgent()
+        ctx_wrap = new_game_agent._build_run_context_wrapper(user_id, conversation_id)
+
+        await agent._initialize_player_context(ctx_wrap, user_id, conversation_id)
+
+    asyncio.run(runner())
+
+    assert ("CurrentLocation", "Town Square") in updates
+    expected_time = "Year 2024 Month Monday Morning"
+    assert ("CurrentTime", expected_time) in updates
+    assert recorded_time_args["args"] == (user_id, conversation_id, 2024, 1, 18, "Morning")
 


### PR DESCRIPTION
## Summary
- enrich the Chase schedule with location cues pulled from the conversation's known locations
- derive the starting time phase and location from the saved schedule when initializing the player context, keeping the stored time keys in sync
- add a regression test that patches the database layer to confirm the player context writes the expected location and time snapshot

## Testing
- pytest --override-ini="addopts=" tests/test_new_game_agent_background.py::test_initialize_player_context_aligns_with_schedule

------
https://chatgpt.com/codex/tasks/task_e_68deb7eec6b8832197b54ba686ea26c1