### PR TITLE
Ensure player context is seeded before opening narrative generation

### DIFF
--- a/tests/test_new_game_agent_background.py
+++ b/tests/test_new_game_agent_background.py
@@ -140,6 +140,15 @@ async def test_process_new_game_does_not_block_on_background(monkeypatch):
         fake_create_player_schedule,
     )
 
+    async def fake_initialize_player_context(self, ctx_wrap, user_id_arg, conversation_id_arg):
+        assert conversation_id_arg == created_conversation_id
+
+    monkeypatch.setattr(
+        new_game_agent.NewGameAgent,
+        "_initialize_player_context",
+        fake_initialize_player_context,
+    )
+
     async def fake_queue_npcs(self, user_id, conversation_id, target_count=5):
         assert conversation_id == created_conversation_id
 

--- a/tests/test_new_game_agent_bootstrap.py
+++ b/tests/test_new_game_agent_bootstrap.py
@@ -182,6 +182,8 @@ async def test_process_new_game_bootstrap_seeds_governance_state(monkeypatch):
     )
 
     async def fake_create_opening(self, ctx_wrap, params):
+        assert state["current_roleplay"].get("CurrentLocation")
+        assert state["current_roleplay"].get("CurrentTime")
         return "Bootstrap opening"
 
     monkeypatch.setattr(new_game_agent.NewGameAgent, "create_opening_narrative", fake_create_opening)


### PR DESCRIPTION
## Summary
- seed the player context after schedule creation so the opening narrative sees CurrentLocation and CurrentTime
- skip redundant player-context initialization in the finalize step and log when location/time are present
- update background/bootstrap tests to reflect the new initialization point and assert the narrative sees the seeded state

## Testing
- pytest tests/test_new_game_agent_bootstrap.py::test_process_new_game_bootstrap_seeds_governance_state tests/test_new_game_agent_background.py::test_process_new_game_does_not_block_on_background -q -o addopts= *(fails: requires pytest-asyncio plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68def23f37588321ae5137385ce90ff4