### PR TITLE
Handle final_output in Nyx feasibility helper

### DIFF
--- a/nyx/nyx_agent/_feasibility_helpers.py
+++ b/nyx/nyx_agent/_feasibility_helpers.py
@@ -157,6 +157,15 @@ def coalesce_agent_output_text(result: Any) -> Optional[str]:
     if result is None:
         return None
 
+    final_output = getattr(result, "final_output", None)
+    if isinstance(final_output, str) and final_output.strip():
+        return final_output.strip()
+
+    if isinstance(result, dict):
+        final_output = result.get("final_output")
+        if isinstance(final_output, str) and final_output.strip():
+            return final_output.strip()
+
     potential_sequences: List[Sequence[Any]] = []
     for attr in ("messages", "history", "events"):
         value = getattr(result, attr, None)


### PR DESCRIPTION
## Summary
- ensure `coalesce_agent_output_text` returns Nyx's `final_output` when available before inspecting history
- cover the new behavior with helper and SDK defer response tests to avoid regressions

## Testing
- pytest --override-ini addopts='' tests/test_feasibility_defer.py::test_coalesce_agent_output_prefers_final_output
- pytest --override-ini addopts='' tests/test_feasibility_defer.py::test_sdk_defer_response_includes_reason_and_tone

------
https://chatgpt.com/codex/tasks/task_e_68e2264e34808321aa26e034cf2914ca