### PR TITLE
Sharpen Nyx defer language for absent targets

### DIFF
--- a/nyx/nyx_agent/_feasibility_helpers.py
+++ b/nyx/nyx_agent/_feasibility_helpers.py
@@ -124,6 +124,18 @@ def build_defer_prompt(context: DeferPromptContext) -> str:
         "Explicitly reference the missing prerequisites and encourage the player to pursue the suggested leads."
     )
 
+    absent_rules = {
+        str((violation or {}).get("rule", "")).lower()
+        for violation in context.violations
+        if isinstance(violation, dict)
+    }
+    if {"npc_absent", "item_absent"} & absent_rules:
+        instructions += (
+            " When the player imagines people or objects that aren't there, let exasperated "
+            "disbelief drip through—call out how imaginary their targets or gear are while "
+            "keeping the given persona prefix."
+        )
+
     return (
         f"{instructions}\n"
         f"Persona prefix: {context.persona_prefix}\n"


### PR DESCRIPTION
## Summary
- inject sharper narrator guidance and violation copy into the fast feasibility gate when players reference missing NPCs or items
- cue Nyx's defer prompt builder to lean into exasperated disbelief whenever absence rules are triggered
- add regression coverage for the new guidance and prompt instructions to prevent language regressions

## Testing
- pytest -o addopts='' tests/test_feasibility_defer.py

------
https://chatgpt.com/codex/tasks/task_e_68e23f7deb108321bfa73bf7bb1d62e1