### PR TITLE
Fix CurrentLocation lookup and add regression test

### DIFF
--- a/nyx/scene_manager_sdk.py
+++ b/nyx/scene_manager_sdk.py
@@ -109,11 +109,16 @@ async def get_location_description(ctx) -> str:
     # Fetch the current location from database
     async with get_db_connection_context() as conn:
         row = await conn.fetchrow("""
-            SELECT value FROM CurrentRoleplay 
-            WHERE user_id = $1 AND conversation_id = $2 AND key = 'current_location'
+            SELECT value FROM CurrentRoleplay
+            WHERE user_id = $1 AND conversation_id = $2 AND key = 'CurrentLocation'
         """, user_id, conversation_id)
-        
+
         if not row or not row["value"]:
+            logger.warning(
+                "Current location lookup failed for user_id=%s conversation_id=%s",
+                user_id,
+                conversation_id,
+            )
             return "Current location not set"
         
         current_location = row["value"]
@@ -127,6 +132,12 @@ async def get_location_description(ctx) -> str:
         if location_row and location_row["description"]:
             return location_row["description"]
         else:
+            logger.warning(
+                "Location description missing for '%s' (user_id=%s conversation_id=%s)",
+                current_location,
+                user_id,
+                conversation_id,
+            )
             return f"No description available for {current_location}"
 
 @function_tool

--- a/tests/test_scene_manager_sdk.py
+++ b/tests/test_scene_manager_sdk.py
@@ -1,0 +1,72 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from nyx.scene_manager_sdk import get_location_description
+
+
+class _StubConnection:
+    def __init__(self, *, user_id, conversation_id, location_name, description):
+        self._user_id = user_id
+        self._conversation_id = conversation_id
+        self._location_name = location_name
+        self._description = description
+
+    async def fetchrow(self, query, *args):
+        if "CurrentRoleplay" in query:
+            assert args == (self._user_id, self._conversation_id)
+            if "'CurrentLocation'" in query:
+                return {"value": self._location_name}
+            return None
+
+        if "FROM Locations" in query:
+            assert args == (self._location_name, self._user_id)
+            return {"description": self._description}
+
+        return None
+
+
+class _StubConnectionContext:
+    def __init__(self, connection):
+        self._connection = connection
+
+    async def __aenter__(self):
+        return self._connection
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+def test_get_location_description_returns_current_location(monkeypatch):
+    user_id = 99
+    conversation_id = "conv-123"
+    expected_description = "A bustling atrium filled with chatter."
+
+    stub_connection = _StubConnection(
+        user_id=user_id,
+        conversation_id=conversation_id,
+        location_name="Atrium",
+        description=expected_description,
+    )
+
+    def _stub_get_db_connection_context():
+        return _StubConnectionContext(stub_connection)
+
+    monkeypatch.setattr(
+        "nyx.scene_manager_sdk.get_db_connection_context",
+        _stub_get_db_connection_context,
+    )
+
+    ctx = SimpleNamespace(
+        context=SimpleNamespace(user_id=user_id, conversation_id=conversation_id)
+    )
+
+    tool_impl = get_location_description.on_invoke_tool.__closure__[0].cell_contents
+    orig_func = tool_impl.__closure__[1].cell_contents
+
+    result = asyncio.run(orig_func(ctx))
+
+    assert result == expected_description


### PR DESCRIPTION
## Summary
- align the CurrentRoleplay query with the canonical `CurrentLocation` key and log when lookups fail
- add a regression test that stubs the database context to ensure populated locations return their descriptions

## Testing
- pytest --override-ini addopts="" tests/test_scene_manager_sdk.py

------
https://chatgpt.com/codex/tasks/task_e_68e2d1c2a6248321bdb8c5f03583038b