### PR TITLE
Add snake_case alias for aggregated roleplay context

### DIFF
--- a/logic/aggregator_sdk.py
+++ b/logic/aggregator_sdk.py
@@ -207,6 +207,7 @@ async def get_aggregated_roleplay_context(user_id: int, conversation_id: int, pl
         # Build base context
         result = {
             'currentRoleplay': current_roleplay,
+            'current_roleplay': current_roleplay,
             'currentLocation': current_location,
             'timeOfDay': time_of_day,
             'playerName': player_name,
@@ -426,8 +427,15 @@ def format_context_for_compatibility(optimized_context: Dict[str, Any]) -> Dict[
     compatible["unintroduced_npcs"] = []
 
     # Current roleplay
+    current_roleplay_data = None
     if "current_roleplay" in optimized_context:
-        compatible["current_roleplay"] = optimized_context["current_roleplay"]
+        current_roleplay_data = optimized_context["current_roleplay"]
+    elif "currentRoleplay" in optimized_context:
+        current_roleplay_data = optimized_context["currentRoleplay"]
+
+    if current_roleplay_data is not None:
+        compatible["current_roleplay"] = current_roleplay_data
+        compatible["currentRoleplay"] = current_roleplay_data
 
     # Location details
     if "location_details" in optimized_context:
@@ -479,11 +487,14 @@ async def fallback_get_context(
     Fallback context retrieval directly from the database.
     """
     try:
+        current_roleplay_state: Dict[str, Any] = {}
+
         minimal_context = {
             "player_stats": {},
             "introduced_npcs": [],
             "unintroduced_npcs": [],
-            "current_roleplay": {},
+            "current_roleplay": current_roleplay_state,
+            "currentRoleplay": current_roleplay_state,
             "year": "1040",
             "month": "6",
             "day": "15",
@@ -556,11 +567,13 @@ async def fallback_get_context(
 
     except Exception as e:
         logger.error(f"Error in fallback_get_context: {e}", exc_info=True)
+        error_roleplay_state: Dict[str, Any] = {}
         return {
             "player_stats": {},
             "introduced_npcs": [],
             "unintroduced_npcs": [],
-            "current_roleplay": {},
+            "current_roleplay": error_roleplay_state,
+            "currentRoleplay": error_roleplay_state,
             "error": str(e)
         }
 

--- a/tests/test_aggregator_sdk_context_keys.py
+++ b/tests/test_aggregator_sdk_context_keys.py
@@ -1,0 +1,114 @@
+import os
+import sys
+import json
+import types
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+dummy_models = types.ModuleType("sentence_transformers.models")
+
+
+class DummySentenceTransformer:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def encode(self, sentences, *args, **kwargs):
+        if isinstance(sentences, list):
+            return [[0.0] * 3 for _ in sentences]
+        return [0.0, 0.0, 0.0]
+
+    def get_sentence_embedding_dimension(self):
+        return 3
+
+
+dummy_sentence_transformers = types.ModuleType("sentence_transformers")
+dummy_sentence_transformers.SentenceTransformer = DummySentenceTransformer
+dummy_sentence_transformers.models = dummy_models
+
+sys.modules.setdefault("sentence_transformers", dummy_sentence_transformers)
+sys.modules.setdefault("sentence_transformers.models", dummy_models)
+
+from logic import aggregator_sdk
+
+
+class DummyConnection:
+    async def fetch(self, query, *args):
+        query_str = " ".join(query.split()) if isinstance(query, str) else str(query)
+
+        if "FROM CurrentRoleplay" in query_str and "NPCStats" not in query_str:
+            return [
+                {"key": "CurrentLocation", "value": json.dumps("Chapel of Thorns")},
+                {"key": "TimeOfDay", "value": json.dumps("Dawn")},
+                {"key": "CurrentDay", "value": json.dumps(2)},
+                {"key": "CurrentYear", "value": json.dumps(2025)},
+                {"key": "CurrentMonth", "value": json.dumps("May")},
+            ]
+
+        if "FROM NPCStats" in query_str:
+            return []
+
+        if "FROM Events" in query_str:
+            return []
+
+        if "FROM Quests" in query_str:
+            return []
+
+        return []
+
+    async def fetchrow(self, query, *args):
+        query_str = " ".join(query.split()) if isinstance(query, str) else str(query)
+
+        if "FROM PlayerStats" in query_str:
+            return {
+                "corruption": 1,
+                "confidence": 2,
+                "willpower": 3,
+                "obedience": 4,
+                "dependency": 5,
+                "lust": 6,
+                "mental_resilience": 7,
+                "physical_endurance": 8,
+            }
+
+        return None
+
+
+class DummyConnectionContext:
+    async def __aenter__(self):
+        return DummyConnection()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def dummy_get_db_connection_context():
+    return DummyConnectionContext()
+
+
+@pytest.mark.asyncio
+async def test_get_aggregated_roleplay_context_exposes_both_spellings(monkeypatch):
+    monkeypatch.setattr(
+        aggregator_sdk,
+        "get_db_connection_context",
+        dummy_get_db_connection_context,
+    )
+
+    async def fake_check_preset_story(conversation_id):
+        return None
+
+    monkeypatch.setattr(
+        aggregator_sdk.PresetStoryManager,
+        "check_preset_story",
+        staticmethod(fake_check_preset_story),
+    )
+
+    context = await aggregator_sdk.get_aggregated_roleplay_context(1, 2, "Chase")
+
+    assert "currentRoleplay" in context
+    assert "current_roleplay" in context
+    assert context["currentRoleplay"] is context["current_roleplay"]
+    assert context["currentRoleplay"]["CurrentLocation"] == "Chapel of Thorns"


### PR DESCRIPTION
## Summary
- expose a `current_roleplay` alias alongside `currentRoleplay` in aggregated and optimized context payloads
- keep fallback context-building paths synchronized with the dual key names
- add a focused unit test that exercises the aggregator and asserts both spellings are present

## Testing
- pytest --no-cov tests/test_aggregator_sdk_context_keys.py

------
https://chatgpt.com/codex/tasks/task_e_68e2e9a40e488321b668a5d79a81acf3