### PR TITLE
Add recent conversation history to Nyx context metadata

### DIFF
--- a/logic/nyx_enhancements_integration.py
+++ b/logic/nyx_enhancements_integration.py
@@ -58,6 +58,7 @@ from db.connection import get_db_connection_context, run_async_in_worker_loop
 
 # Performance monitoring
 from utils.performance import PerformanceTracker, timed_function
+from utils.conversation_history import fetch_recent_turns
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -178,10 +179,13 @@ async def enhanced_background_chat_task(
         # Build context metadata
         performance_tracker.start_phase("context_preparation")
         
+        recent_turns = await fetch_recent_turns(user_id, conversation_id)
+
         metadata = {
             "background_task": True,
             "timestamp": time.time()
         }
+        metadata["recent_turns"] = recent_turns
         
         # Add universal update if provided
         if universal_update:
@@ -212,6 +216,7 @@ async def enhanced_background_chat_task(
                         metadata["npc_present"] = [npc.get("npc_id") for npc in npcs_data if npc.get("npc_id")]
                     except:
                         pass
+
                         
         except Exception as e:
             logger.warning(f"Could not fetch scene context: {e}")

--- a/nyx/nyx_agent/orchestrator.py
+++ b/nyx/nyx_agent/orchestrator.py
@@ -143,6 +143,31 @@ def _normalize_scene_context(context: Optional[Dict[str, Any]]) -> Dict[str, Any
         default_factory=list,
         coerce_list=True,
     )
+    adopt(
+        "recent_interactions",
+        ("recent_turns", "recent_dialogue", "recent_messages"),
+        default_factory=list,
+        coerce_list=True,
+    )
+
+    if isinstance(normalized.get("recent_interactions"), list):
+        canonical_turns: List[Dict[str, Any]] = []
+        for entry in normalized.get("recent_interactions", []):
+            if not isinstance(entry, dict):
+                continue
+            sender = entry.get("sender")
+            content = entry.get("content")
+            if sender is None and content is None:
+                continue
+            turn: Dict[str, Any] = {}
+            if sender is not None:
+                turn["sender"] = sender
+            if content is not None:
+                turn["content"] = content
+            canonical_turns.append(turn)
+        normalized["recent_interactions"] = canonical_turns
+        if not _is_meaningful(normalized.get("recent_turns")):
+            normalized["recent_turns"] = canonical_turns
 
     if not _is_meaningful(normalized.get("present_entities")):
         normalized["present_entities"] = list(normalized.get("present_npcs", []))

--- a/routes/story_routes.py
+++ b/routes/story_routes.py
@@ -32,6 +32,7 @@ from utils.db_helpers import db_transaction, with_transaction, handle_database_o
 from utils.performance import PerformanceTracker, timed_function, STATS
 from utils.caching import NPC_CACHE, LOCATION_CACHE, AGGREGATOR_CACHE, TIME_CACHE, COMPUTATION_CACHE, cache
 from utils.performance import timed_function
+from utils.conversation_history import fetch_recent_turns
 
 # Import core logic modules
 from db.connection import get_db_connection_context
@@ -1690,13 +1691,15 @@ async def next_storybeat():
         # 2) Build aggregator context
         tracker.start_phase("get_context")
         aggregator_data = await get_aggregated_roleplay_context(user_id, conv_id, player_name)
+        recent_turns = await fetch_recent_turns(user_id, conv_id)
         context = {
             "location": aggregator_data.get("currentRoleplay", {}).get("CurrentLocation", "Unknown"),
             "time_of_day": aggregator_data.get("timeOfDay", "Morning"),
             "player_input": user_input,
             "player_name": player_name,
             # You can pass the entire aggregator if desired:
-            "aggregator_data": aggregator_data
+            "aggregator_data": aggregator_data,
+            "recent_turns": recent_turns,
         }
         tracker.end_phase()
 

--- a/tests/test_recent_turns_context.py
+++ b/tests/test_recent_turns_context.py
@@ -1,0 +1,102 @@
+import os
+import sys
+import types
+from pathlib import Path
+import typing
+
+from typing_extensions import TypedDict as _CompatTypedDict
+
+import asyncio
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+typing.TypedDict = _CompatTypedDict  # type: ignore[attr-defined]
+
+
+class _StubSentenceTransformer:  # pragma: no cover - simple stub
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def encode(self, *args, **kwargs):
+        return []
+
+
+stub_sentence_transformers = types.ModuleType("sentence_transformers")
+stub_sentence_transformers.SentenceTransformer = _StubSentenceTransformer
+sys.modules.setdefault("sentence_transformers", stub_sentence_transformers)
+
+stub_conflict_synthesizer = types.ModuleType("logic.conflict_system.conflict_synthesizer")
+stub_conflict_synthesizer.get_synthesizer = lambda *args, **kwargs: None
+stub_conflict_synthesizer.ConflictSynthesizer = object
+stub_conflict_synthesizer.ConflictContext = object
+stub_conflict_synthesizer.SubsystemType = object
+stub_conflict_synthesizer.EventType = object
+stub_conflict_synthesizer.SystemEvent = object
+
+stub_conflict_background = types.ModuleType("logic.conflict_system.background_processor")
+stub_conflict_background.get_conflict_scheduler = lambda *args, **kwargs: None
+
+stub_conflict_pkg = types.ModuleType("logic.conflict_system")
+stub_conflict_pkg.conflict_synthesizer = stub_conflict_synthesizer
+stub_conflict_pkg.background_processor = stub_conflict_background
+
+sys.modules.setdefault("logic.conflict_system", stub_conflict_pkg)
+sys.modules["logic.conflict_system.conflict_synthesizer"] = stub_conflict_synthesizer
+sys.modules["logic.conflict_system.background_processor"] = stub_conflict_background
+
+from nyx.nyx_agent.context import (
+    BundleSection,
+    ContextBundle,
+    NyxContext,
+    SceneScope,
+)
+
+
+class _StubBroker:
+    def __init__(self, bundle: ContextBundle) -> None:
+        self._bundle = bundle
+
+    async def compute_scene_scope(self, user_input, current_context):
+        return self._bundle.scene_scope
+
+    async def load_or_fetch_bundle(self, scene_scope):
+        return self._bundle
+
+    def log_metrics_line(self, scene_key, packed_context):  # pragma: no cover - noop
+        return None
+
+
+def test_recent_turns_propagated_into_bundle_metadata():
+    scene_scope = SceneScope()
+    bundle = ContextBundle(
+        scene_scope=scene_scope,
+        npcs=BundleSection(data={}, canonical=True),
+        memories=BundleSection(data={}, canonical=True),
+        lore=BundleSection(data={}, canonical=True),
+        conflicts=BundleSection(data={}, canonical=True),
+        world=BundleSection(data={}, canonical=True),
+        narrative=BundleSection(data={}, canonical=True),
+        metadata={},
+    )
+    broker = _StubBroker(bundle)
+
+    context = NyxContext(user_id=1, conversation_id=2, context_broker=broker)
+    context.current_context["recent_turns"] = [
+        {"sender": "User", "content": "Hello"},
+        {"sender": "Nyx", "content": "Welcome"},
+    ]
+
+    asyncio.run(context.build_context_for_input("How are things?", {}))
+
+    assert bundle.metadata["recent_interactions"] == [
+        {"sender": "User", "content": "Hello"},
+        {"sender": "Nyx", "content": "Welcome"},
+    ]
+    assert bundle.narrative.data.get("recent") == [
+        {"sender": "User", "content": "Hello"},
+        {"sender": "Nyx", "content": "Welcome"},
+    ]
+    assert context.current_context["recent_turns"] == [
+        {"sender": "User", "content": "Hello"},
+        {"sender": "Nyx", "content": "Welcome"},
+    ]

--- a/utils/conversation_history.py
+++ b/utils/conversation_history.py
@@ -1,0 +1,101 @@
+"""Helper utilities for retrieving recent conversation history."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Union
+
+from db.connection import get_db_connection_context
+
+logger = logging.getLogger(__name__)
+
+
+Number = Union[int, str]
+
+
+def _coerce_int(value: Number, *, name: str) -> int:
+    """Safely coerce ``value`` to ``int`` for SQL parameters."""
+
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        logger.warning("Failed to coerce %s=%r to int for recent turn fetch", name, value)
+        raise
+
+
+def _normalize_turn(entry: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return a turn payload limited to ``sender``/``content`` keys."""
+
+    sender = entry.get("sender")
+    content = entry.get("content")
+    normalized: Dict[str, Any] = {}
+    if sender is not None:
+        normalized["sender"] = sender
+    if content is not None:
+        normalized["content"] = content
+    return normalized
+
+
+async def fetch_recent_turns(
+    user_id: Number,
+    conversation_id: Number,
+    limit: int = 8,
+) -> List[Dict[str, Any]]:
+    """Fetch the latest ``limit`` conversation turns for Nyx context assembly.
+
+    The turns are returned in chronological order and contain only the
+    ``sender`` and ``content`` fields. Any missing or malformed rows are
+    filtered out to protect downstream prompt assembly.
+    """
+
+    if limit <= 0:
+        return []
+
+    try:
+        user_id_int = _coerce_int(user_id, name="user_id")
+        conversation_id_int = _coerce_int(conversation_id, name="conversation_id")
+    except Exception:
+        return []
+
+    query = """
+        SELECT m.sender, m.content
+        FROM messages AS m
+        JOIN conversations AS c ON c.id = m.conversation_id
+        WHERE c.user_id = $1
+          AND m.conversation_id = $2
+        ORDER BY m.created_at DESC
+        LIMIT $3
+    """
+
+    try:
+        async with get_db_connection_context() as conn:
+            rows: Sequence[Mapping[str, Any]] = await conn.fetch(
+                query,
+                user_id_int,
+                conversation_id_int,
+                limit,
+            )
+    except Exception:
+        logger.exception(
+            "Failed to fetch recent turns for user_id=%s conversation_id=%s",
+            user_id_int,
+            conversation_id_int,
+        )
+        return []
+
+    # Reverse once to chronological order (oldest → newest)
+    ordered: Iterable[Mapping[str, Any]] = reversed(rows)
+
+    turns: List[Dict[str, Any]] = []
+    for row in ordered:
+        if not isinstance(row, Mapping):
+            continue
+        normalized = _normalize_turn(row)
+        if normalized:
+            turns.append(normalized)
+
+    return turns
+
+
+__all__ = ["fetch_recent_turns"]
+


### PR DESCRIPTION
## Summary
- add a shared async helper that retrieves the latest conversation turns for a user/conversation pair via the DB connection context
- surface the recent turn history in all Nyx orchestration entry points so it flows through normalization and NyxContext bundle metadata
- extend NyxContext and its normalizer to preserve the turn list and cover the behavior with a lightweight unit test

## Testing
- pytest tests/test_recent_turns_context.py --override-ini=addopts=


------
https://chatgpt.com/codex/tasks/task_e_68e4713631e88321b7eb614fed9146d3