### PR TITLE
Persist canonical snapshots for Nyx side effects

### DIFF
--- a/nyx/tasks/background/conflict_tasks.py
+++ b/nyx/tasks/background/conflict_tasks.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 from celery import shared_task
 
 from nyx.conversation.snapshot_store import ConversationSnapshotStore
+from nyx.nyx_agent.context import (
+    build_canonical_snapshot_payload,
+    fetch_canonical_snapshot,
+    persist_canonical_snapshot,
+)
 from nyx.utils.idempotency import idempotent
 
 logger = logging.getLogger(__name__)
@@ -17,6 +23,46 @@ _SNAPSHOTS = ConversationSnapshotStore()
 
 def _idempotency_key(payload: Dict[str, Any]) -> str:
     return f"conflict:{payload.get('conversation_id')}:{payload.get('turn_id')}"
+
+
+def _run_coro(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _coerce_ids(user_id: str, conversation_id: str) -> Optional[Tuple[int, int]]:
+    try:
+        return int(user_id), int(conversation_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def _hydrate_snapshot(user_id: str, conversation_id: str) -> Dict[str, Any]:
+    snapshot = _SNAPSHOTS.get(user_id, conversation_id)
+    if snapshot:
+        return snapshot
+    ids = _coerce_ids(user_id, conversation_id)
+    if not ids:
+        return snapshot
+    canonical = _run_coro(fetch_canonical_snapshot(*ids))
+    if canonical:
+        hydrated = dict(canonical)
+        _SNAPSHOTS.put(user_id, conversation_id, hydrated)
+        return hydrated
+    return snapshot
+
+
+def _persist_snapshot(user_id: str, conversation_id: str, snapshot: Dict[str, Any]) -> None:
+    ids = _coerce_ids(user_id, conversation_id)
+    if not ids:
+        return
+    payload = build_canonical_snapshot_payload(snapshot)
+    if not payload:
+        return
+    _run_coro(persist_canonical_snapshot(ids[0], ids[1], payload))
 
 
 @shared_task(name="nyx.tasks.background.conflict_tasks.process_events", acks_late=True)
@@ -31,10 +77,11 @@ def process_events(payload: Dict[str, Any]) -> Dict[str, Any] | None:
     user_id = str(payload.get("user_id", ""))
     turn_id = payload.get("turn_id")
 
-    snapshot = _SNAPSHOTS.get(user_id, conversation_id)
+    snapshot = _hydrate_snapshot(user_id, conversation_id)
     history = snapshot.setdefault("conflict_history", [])
     history.append({"turn_id": turn_id, "payload": payload.get("payload", {})})
     _SNAPSHOTS.put(user_id, conversation_id, snapshot)
+    _persist_snapshot(user_id, conversation_id, snapshot)
 
     logger.debug("Processed conflict events for turn=%s conversation=%s", turn_id, conversation_id)
     return {"status": "queued", "turn_id": turn_id}

--- a/nyx/tasks/background/lore_tasks.py
+++ b/nyx/tasks/background/lore_tasks.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 from celery import shared_task
 
 from nyx.conversation.snapshot_store import ConversationSnapshotStore
+from nyx.nyx_agent.context import (
+    build_canonical_snapshot_payload,
+    fetch_canonical_snapshot,
+    persist_canonical_snapshot,
+)
 from nyx.utils.idempotency import idempotent
 
 logger = logging.getLogger(__name__)
@@ -17,6 +23,46 @@ _SNAPSHOTS = ConversationSnapshotStore()
 
 def _idempotency_key(payload: Dict[str, Any]) -> str:
     return f"lore:{payload.get('scene_id')}:{payload.get('region_id')}:{payload.get('turn_id')}"
+
+
+def _run_coro(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _coerce_ids(user_id: str, conversation_id: str) -> Optional[Tuple[int, int]]:
+    try:
+        return int(user_id), int(conversation_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def _hydrate_snapshot(user_id: str, conversation_id: str) -> Dict[str, Any]:
+    snapshot = _SNAPSHOTS.get(user_id, conversation_id)
+    if snapshot:
+        return snapshot
+    ids = _coerce_ids(user_id, conversation_id)
+    if not ids:
+        return snapshot
+    canonical = _run_coro(fetch_canonical_snapshot(*ids))
+    if canonical:
+        hydrated = dict(canonical)
+        _SNAPSHOTS.put(user_id, conversation_id, hydrated)
+        return hydrated
+    return snapshot
+
+
+def _persist_snapshot(user_id: str, conversation_id: str, snapshot: Dict[str, Any]) -> None:
+    ids = _coerce_ids(user_id, conversation_id)
+    if not ids:
+        return
+    payload = build_canonical_snapshot_payload(snapshot)
+    if not payload:
+        return
+    _run_coro(persist_canonical_snapshot(ids[0], ids[1], payload))
 
 
 @shared_task(name="nyx.tasks.background.lore_tasks.precompute_scene_bundle", acks_late=True)
@@ -31,7 +77,7 @@ def precompute_scene_bundle(payload: Dict[str, Any]) -> Dict[str, Any] | None:
     user_id = str(payload.get("user_id", ""))
     turn_id = payload.get("turn_id")
 
-    snapshot = _SNAPSHOTS.get(user_id, conversation_id)
+    snapshot = _hydrate_snapshot(user_id, conversation_id)
     lore_log = snapshot.setdefault("lore_requests", [])
     lore_log.append({
         "turn_id": turn_id,
@@ -39,6 +85,7 @@ def precompute_scene_bundle(payload: Dict[str, Any]) -> Dict[str, Any] | None:
         "region_id": payload.get("region_id"),
     })
     _SNAPSHOTS.put(user_id, conversation_id, snapshot)
+    _persist_snapshot(user_id, conversation_id, snapshot)
 
     logger.debug(
         "Lore precompute queued turn=%s scene=%s region=%s",

--- a/nyx/tasks/background/npc_tasks.py
+++ b/nyx/tasks/background/npc_tasks.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 from celery import shared_task
 
 from nyx.conversation.snapshot_store import ConversationSnapshotStore
+from nyx.nyx_agent.context import (
+    build_canonical_snapshot_payload,
+    fetch_canonical_snapshot,
+    persist_canonical_snapshot,
+)
 from nyx.utils.idempotency import idempotent
 
 logger = logging.getLogger(__name__)
@@ -17,6 +23,46 @@ _SNAPSHOTS = ConversationSnapshotStore()
 
 def _idempotency_key(payload: Dict[str, Any]) -> str:
     return f"npc:{payload.get('conversation_id')}:{payload.get('turn_id')}"
+
+
+def _run_coro(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _coerce_ids(user_id: str, conversation_id: str) -> Optional[Tuple[int, int]]:
+    try:
+        return int(user_id), int(conversation_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def _hydrate_snapshot(user_id: str, conversation_id: str) -> Dict[str, Any]:
+    snapshot = _SNAPSHOTS.get(user_id, conversation_id)
+    if snapshot:
+        return snapshot
+    ids = _coerce_ids(user_id, conversation_id)
+    if not ids:
+        return snapshot
+    canonical = _run_coro(fetch_canonical_snapshot(*ids))
+    if canonical:
+        hydrated = dict(canonical)
+        _SNAPSHOTS.put(user_id, conversation_id, hydrated)
+        return hydrated
+    return snapshot
+
+
+def _persist_snapshot(user_id: str, conversation_id: str, snapshot: Dict[str, Any]) -> None:
+    ids = _coerce_ids(user_id, conversation_id)
+    if not ids:
+        return
+    payload = build_canonical_snapshot_payload(snapshot)
+    if not payload:
+        return
+    _run_coro(persist_canonical_snapshot(ids[0], ids[1], payload))
 
 
 @shared_task(name="nyx.tasks.background.npc_tasks.run_adaptation_cycle", acks_late=True)
@@ -31,7 +77,7 @@ def run_adaptation_cycle(payload: Dict[str, Any]) -> Dict[str, Any] | None:
     user_id = str(payload.get("user_id", ""))
     turn_id = payload.get("turn_id")
 
-    snapshot = _SNAPSHOTS.get(user_id, conversation_id)
+    snapshot = _hydrate_snapshot(user_id, conversation_id)
     npc_log = snapshot.setdefault("npc_events", [])
     npc_log.append({
         "turn_id": turn_id,
@@ -39,6 +85,7 @@ def run_adaptation_cycle(payload: Dict[str, Any]) -> Dict[str, Any] | None:
         "payload": payload.get("payload", {}),
     })
     _SNAPSHOTS.put(user_id, conversation_id, snapshot)
+    _persist_snapshot(user_id, conversation_id, snapshot)
 
     logger.debug(
         "NPC adaptation queued turn=%s conversation=%s count=%s",

--- a/nyx/tasks/background/world_tasks.py
+++ b/nyx/tasks/background/world_tasks.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 from celery import shared_task
 
 from nyx.conversation.snapshot_store import ConversationSnapshotStore
+from nyx.nyx_agent.context import (
+    build_canonical_snapshot_payload,
+    fetch_canonical_snapshot,
+    persist_canonical_snapshot,
+)
 from nyx.utils.idempotency import idempotent
 from nyx.utils.versioning import reject_if_stale
 
@@ -18,6 +24,46 @@ _SNAPSHOTS = ConversationSnapshotStore()
 
 def _idempotency_key(payload: Dict[str, Any]) -> str:
     return f"world:{payload.get('conversation_id')}:{payload.get('turn_id')}"
+
+
+def _run_coro(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _coerce_ids(user_id: str, conversation_id: str) -> Optional[Tuple[int, int]]:
+    try:
+        return int(user_id), int(conversation_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def _hydrate_snapshot(user_id: str, conversation_id: str) -> Dict[str, Any]:
+    snapshot = _SNAPSHOTS.get(user_id, conversation_id)
+    if snapshot:
+        return snapshot
+    ids = _coerce_ids(user_id, conversation_id)
+    if not ids:
+        return snapshot
+    canonical = _run_coro(fetch_canonical_snapshot(*ids))
+    if canonical:
+        hydrated = dict(canonical)
+        _SNAPSHOTS.put(user_id, conversation_id, hydrated)
+        return hydrated
+    return snapshot
+
+
+def _persist_snapshot(user_id: str, conversation_id: str, snapshot: Dict[str, Any]) -> None:
+    ids = _coerce_ids(user_id, conversation_id)
+    if not ids:
+        return
+    payload = build_canonical_snapshot_payload(snapshot)
+    if not payload:
+        return
+    _run_coro(persist_canonical_snapshot(ids[0], ids[1], payload))
 
 
 @shared_task(name="nyx.tasks.background.world_tasks.apply_universal", acks_late=True)
@@ -34,7 +80,7 @@ def apply_universal(payload: Dict[str, Any]) -> Dict[str, Any] | None:
     incoming_world_version = payload.get("incoming_world_version", 0)
     deltas = payload.get("deltas") or {}
 
-    snapshot = _SNAPSHOTS.get(user_id, conversation_id)
+    snapshot = _hydrate_snapshot(user_id, conversation_id)
     current_version = snapshot.get("world_version", 0)
 
     if not reject_if_stale(current_version, incoming_world_version):
@@ -62,6 +108,7 @@ def apply_universal(payload: Dict[str, Any]) -> Dict[str, Any] | None:
     if deltas:
         snapshot.setdefault("pending_world_deltas", []).append({"turn_id": turn_id, "deltas": deltas})
     _SNAPSHOTS.put(user_id, conversation_id, snapshot)
+    _persist_snapshot(user_id, conversation_id, snapshot)
     return {"status": "queued", "version": incoming_world_version}
 
 


### PR DESCRIPTION
## Summary
- add helpers to build, persist, and fetch reduced conversation snapshots from canon and hydrate Nyx context on initialization
- persist reduced snapshots during side-effect packaging and reuse the same canonical helper from background tasks
- ensure background tasks hydrate from the canonical snapshot when caches are empty and resync canon after mutations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e539f4027083218a2f86de8099e07a