### PR TITLE
Persist current location synchronously

### DIFF
--- a/tests/test_nyx_location_refresh.py
+++ b/tests/test_nyx_location_refresh.py
@@ -227,6 +227,15 @@ class _AsyncNullConnection:  # pragma: no cover - db shim
     async def fetchrow(self, *args, **kwargs):
         return None
 
+    async def execute(self, *args, **kwargs):
+        return None
+
+    async def fetch(self, *args, **kwargs):
+        return []
+
+    async def fetchval(self, *args, **kwargs):
+        return 1
+
 
 stub_db_connection.get_db_connection_context = lambda: _AsyncNullConnection()
 stub_db_connection.is_shutting_down = lambda: False


### PR DESCRIPTION
## Summary
- await location refresh persistence inside NyxContext so CurrentLocation rows are written before the event loop exits
- extend the nyx location refresh test stub connection with execute/fetch helpers to support the awaited persistence path

## Testing
- pytest --override-ini addopts='' tests/test_nyx_location_refresh.py

------
https://chatgpt.com/codex/tasks/task_e_68e58404e30c83218c5bf4ffaf8f46bc